### PR TITLE
Add OVN_MTU from ovn-config to cniprovisioner

### DIFF
--- a/helm/ovn-kubernetes/charts/ovnkube-node-dpu/templates/ovnkube-node-dpu.yaml
+++ b/helm/ovn-kubernetes/charts/ovnkube-node-dpu/templates/ovnkube-node-dpu.yaml
@@ -171,6 +171,11 @@ spec:
         {{- else }}
         - name: VTEP_CIDR
           value: {{ default "" .Values.vtepCIDR | quote }}
+        - name: OVN_MTU
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: mtu
         {{- end }}
         - name: HOST_CIDR
           value: {{ default "" .Values.hostCIDR | quote }}


### PR DESCRIPTION
This PR is adding a env variable OVN_MTU to the cniprovisioner to be able to change the MTU of the PF on the host.
The CNI must add the geneve header size of 60 bytes to the MTU value.