### PR TITLE
feat: add new chart that aligns with DPF contract

### DIFF
--- a/helm/ovn-kubernetes-dpf/Chart.yaml
+++ b/helm/ovn-kubernetes-dpf/Chart.yaml
@@ -1,0 +1,15 @@
+apiVersion: v2
+name: ovn-kubernetes-chart
+description: Helm chart to deploy ovn-kubernetes in the NVIDIA DOCA Platform Framework (DPF) context
+type: application
+version: 1.0.0
+appVersion: "1.0.0"
+home: https://ovn-kubernetes.io/
+icon: https://www.ovn.org/images/ovn-logo.png
+sources:
+- https://github.com/ovn-org/ovn-kubernetes
+- https://github.com/ovn-org/ovn
+dependencies:
+- name: ovn-kubernetes-resource-injector
+  version: 1.0.0
+  condition: ovn-kubernetes-resource-injector.enabled

--- a/helm/ovn-kubernetes-dpf/charts/ovn-kubernetes-resource-injector/.helmignore
+++ b/helm/ovn-kubernetes-dpf/charts/ovn-kubernetes-resource-injector/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helm/ovn-kubernetes-dpf/charts/ovn-kubernetes-resource-injector/Chart.yaml
+++ b/helm/ovn-kubernetes-dpf/charts/ovn-kubernetes-resource-injector/Chart.yaml
@@ -1,0 +1,21 @@
+apiVersion: v2
+name: ovn-kubernetes-resource-injector
+description: A Helm chart for Kubernetes
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 1.0.0
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.0.0"

--- a/helm/ovn-kubernetes-dpf/charts/ovn-kubernetes-resource-injector/templates/_helpers.tpl
+++ b/helm/ovn-kubernetes-dpf/charts/ovn-kubernetes-resource-injector/templates/_helpers.tpl
@@ -1,0 +1,84 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "ovn-kubernetes-resource-injector.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 50 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 50 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "ovn-kubernetes-resource-injector.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 50 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 50 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 50 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "ovn-kubernetes-resource-injector.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 50 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "ovn-kubernetes-resource-injector.labels" -}}
+helm.sh/chart: {{ include "ovn-kubernetes-resource-injector.chart" . }}
+{{ include "ovn-kubernetes-resource-injector.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "ovn-kubernetes-resource-injector.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "ovn-kubernetes-resource-injector.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+The name of the webhook certificate
+*/}}
+{{- define "ovn-kubernetes-resource-injector.webhook.certificateName" -}}
+{{ include "ovn-kubernetes-resource-injector.fullname" . }}-webhook
+{{- end }}
+
+{{/*
+The name of the webhook secret that contains the certificate
+*/}}
+{{- define "ovn-kubernetes-resource-injector.webhook.secretName" -}}
+{{ include "ovn-kubernetes-resource-injector.fullname" . }}-webhook-cert
+{{- end }}
+
+{{/*
+The name of the webhook service
+*/}}
+{{- define "ovn-kubernetes-resource-injector.webhook.serviceName" -}}
+{{ include "ovn-kubernetes-resource-injector.fullname" . }}-webhook
+{{- end }}
+
+
+{{/*
+The args to be passed to the webhook
+*/}}
+{{- define "ovn-kubernetes-resource-injector.webhook.args" -}}
+{{- $args := .Values.controllerManager.webhook.args }}
+{{- $args = append $args (printf "--nad-namespace=%s" .Release.Namespace) }}
+{{- $args = append $args (printf "--nad-name=%s" .Values.nadName) }}
+{{- toYaml $args }}
+{{- end }}
+

--- a/helm/ovn-kubernetes-dpf/charts/ovn-kubernetes-resource-injector/templates/deployment.yaml
+++ b/helm/ovn-kubernetes-dpf/charts/ovn-kubernetes-resource-injector/templates/deployment.yaml
@@ -1,0 +1,71 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "ovn-kubernetes-resource-injector.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    dpu.nvidia.com/component: ovn-kubernetes-resource-injector
+  {{- include "ovn-kubernetes-resource-injector.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.controllerManager.replicas }}
+  selector:
+    matchLabels:
+      dpu.nvidia.com/component: ovn-kubernetes-resource-injector
+    {{- include "ovn-kubernetes-resource-injector.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        dpu.nvidia.com/component: ovn-kubernetes-resource-injector
+      {{- include "ovn-kubernetes-resource-injector.selectorLabels" . | nindent 8 }}
+        ovn.dpu.nvidia.com/skip-injection: ""
+    spec:
+      containers:
+      - args: {{- include "ovn-kubernetes-resource-injector.webhook.args" . | nindent 8 }}
+        command: {{- toYaml .Values.controllerManager.webhook.command | nindent 8 }}
+        image: {{ .Values.controllerManager.webhook.image.repository }}:{{ .Values.controllerManager.webhook.image.tag
+          | default .Chart.AppVersion }}
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        name: webhook
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources: {{- toYaml .Values.controllerManager.webhook.resources | nindent 10
+          }}
+        securityContext: {{- toYaml .Values.controllerManager.webhook.containerSecurityContext
+          | nindent 10 }}
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        volumeMounts:
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: cert
+          readOnly: true
+      {{- if .Values.global.imagePullSecretName }}
+      imagePullSecrets:
+      - name: {{ .Values.global.imagePullSecretName }}
+      {{- end }}
+      securityContext:
+      serviceAccountName: {{ include "ovn-kubernetes-resource-injector.fullname" . }}
+      terminationGracePeriodSeconds: 10
+      {{- with .Values.controllerManager.nodeSelector }}
+      nodeSelector:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.controllerManager.tolerations }}
+      tolerations:
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
+      volumes:
+      - name: cert
+        secret:
+          defaultMode: 420
+          secretName: {{ include "ovn-kubernetes-resource-injector.webhook.secretName" . }}

--- a/helm/ovn-kubernetes-dpf/charts/ovn-kubernetes-resource-injector/templates/leader-election-rbac.yaml
+++ b/helm/ovn-kubernetes-dpf/charts/ovn-kubernetes-resource-injector/templates/leader-election-rbac.yaml
@@ -1,0 +1,57 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "ovn-kubernetes-resource-injector.fullname" . }}-leader-election-role
+  namespace: {{ .Release.Namespace }}
+  labels:
+    dpu.nvidia.com/component: ovn-kubernetes-resource-injector
+  {{- include "ovn-kubernetes-resource-injector.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "ovn-kubernetes-resource-injector.fullname" . }}-leader-election-rolebinding
+  namespace: {{ .Release.Namespace }}
+  labels:
+    dpu.nvidia.com/component: ovn-kubernetes-resource-injector
+  {{- include "ovn-kubernetes-resource-injector.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: '{{ include "ovn-kubernetes-resource-injector.fullname" . }}-leader-election-role'
+subjects:
+- kind: ServiceAccount
+  name: '{{ include "ovn-kubernetes-resource-injector.fullname" . }}'
+  namespace: '{{ .Release.Namespace }}'

--- a/helm/ovn-kubernetes-dpf/charts/ovn-kubernetes-resource-injector/templates/manager-rbac.yaml
+++ b/helm/ovn-kubernetes-dpf/charts/ovn-kubernetes-resource-injector/templates/manager-rbac.yaml
@@ -1,0 +1,32 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "ovn-kubernetes-resource-injector.fullname" . }}-role
+  labels:
+    dpu.nvidia.com/component: ovn-kubernetes-resource-injector
+  {{- include "ovn-kubernetes-resource-injector.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - k8s.cni.cncf.io
+  resources:
+  - network-attachment-definitions
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "ovn-kubernetes-resource-injector.fullname" . }}-rolebinding
+  labels:
+    dpu.nvidia.com/component: ovn-kubernetes-resource-injector
+  {{- include "ovn-kubernetes-resource-injector.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: '{{ include "ovn-kubernetes-resource-injector.fullname" . }}-role'
+subjects:
+- kind: ServiceAccount
+  name: '{{ include "ovn-kubernetes-resource-injector.fullname" . }}'
+  namespace: '{{ .Release.Namespace }}'

--- a/helm/ovn-kubernetes-dpf/charts/ovn-kubernetes-resource-injector/templates/mutatingwebhookconfiguration.yaml
+++ b/helm/ovn-kubernetes-dpf/charts/ovn-kubernetes-resource-injector/templates/mutatingwebhookconfiguration.yaml
@@ -1,0 +1,34 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  labels:
+    dpu.nvidia.com/component: ovn-kubernetes-resource-injector
+    {{- include "ovn-kubernetes-resource-injector.labels" . | nindent 4 }}
+  annotations:
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "ovn-kubernetes-resource-injector.webhook.certificateName" . }}
+  name: {{ include "ovn-kubernetes-resource-injector.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: {{ include "ovn-kubernetes-resource-injector.fullname" . }}-webhook
+      namespace: {{ .Release.Namespace }}
+      path: /mutate--v1-pod
+  failurePolicy: Fail
+  name: ovn.dpu.nvidia.com
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    resources:
+    - pods
+  sideEffects: None
+  objectSelector:
+    matchExpressions:
+    - key: ovn.dpu.nvidia.com/skip-injection
+      operator: DoesNotExist

--- a/helm/ovn-kubernetes-dpf/charts/ovn-kubernetes-resource-injector/templates/nad.yaml
+++ b/helm/ovn-kubernetes-dpf/charts/ovn-kubernetes-resource-injector/templates/nad.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: {{ .Values.nadName }}
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    k8s.v1.cni.cncf.io/resourceName: {{ .Values.resourceName }} 
+spec:
+  config: '{
+    "cniVersion" : "0.4.0",
+    "name" : "ovn-primary",
+    "type" : "ovn-k8s-cni-overlay",
+    "logFile": "/var/log/ovn-kubernetes/ovn-k8s-cni-overlay.log",
+    "logLevel": "5",
+    "logfile-maxsize": 100,
+    "logfile-maxbackups": 5,
+    "logfile-maxage": 5
+    }'
+

--- a/helm/ovn-kubernetes-dpf/charts/ovn-kubernetes-resource-injector/templates/serviceaccount.yaml
+++ b/helm/ovn-kubernetes-dpf/charts/ovn-kubernetes-resource-injector/templates/serviceaccount.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "ovn-kubernetes-resource-injector.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    dpu.nvidia.com/component: ovn-kubernetes-resource-injector
+  {{- include "ovn-kubernetes-resource-injector.labels" . | nindent 4 }}
+  annotations:
+    {{- toYaml .Values.controllerManager.serviceAccount.annotations | nindent 4 }}

--- a/helm/ovn-kubernetes-dpf/charts/ovn-kubernetes-resource-injector/templates/webhook-certificate.yaml
+++ b/helm/ovn-kubernetes-dpf/charts/ovn-kubernetes-resource-injector/templates/webhook-certificate.yaml
@@ -1,0 +1,28 @@
+{{- $issuerName := include "ovn-kubernetes-resource-injector.fullname" . -}}
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  labels:
+    dpu.nvidia.com/component: ovn-kubernetes-resource-injector
+    {{- include "ovn-kubernetes-resource-injector.labels" . | nindent 4 }}
+  name: {{ $issuerName }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    dpu.nvidia.com/component: ovn-kubernetes-resource-injector
+    {{- include "ovn-kubernetes-resource-injector.labels" . | nindent 4 }}
+  name: {{ include "ovn-kubernetes-resource-injector.webhook.certificateName" . }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  dnsNames:
+  - {{ include "ovn-kubernetes-resource-injector.webhook.serviceName" . }}.{{ .Release.Namespace }}.svc
+  - {{ include "ovn-kubernetes-resource-injector.webhook.serviceName" . }}.{{ .Release.Namespace }}.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: {{ $issuerName }}
+  secretName: {{ include "ovn-kubernetes-resource-injector.webhook.secretName" . }}

--- a/helm/ovn-kubernetes-dpf/charts/ovn-kubernetes-resource-injector/templates/webhook-service.yaml
+++ b/helm/ovn-kubernetes-dpf/charts/ovn-kubernetes-resource-injector/templates/webhook-service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    dpu.nvidia.com/component: ovn-kubernetes-resource-injector
+    {{- include "ovn-kubernetes-resource-injector.labels" . | nindent 4 }}
+  name: {{ include "ovn-kubernetes-resource-injector.webhook.serviceName" . }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  ports:
+  - port: 443
+    protocol: TCP
+    targetPort: 9443
+  selector:
+    dpu.nvidia.com/component: ovn-kubernetes-resource-injector
+    {{- include "ovn-kubernetes-resource-injector.selectorLabels" . | nindent 4 }}

--- a/helm/ovn-kubernetes-dpf/charts/ovn-kubernetes-resource-injector/values.yaml
+++ b/helm/ovn-kubernetes-dpf/charts/ovn-kubernetes-resource-injector/values.yaml
@@ -1,0 +1,35 @@
+controllerManager:
+  webhook:
+    command:
+    - /manager
+    args:
+    - --leader-elect
+    containerSecurityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+    image:
+      repository: example.com/ovn-kubernetes-resource-injector
+      tag: v0.1.0
+    resources:
+      limits:
+        cpu: 500m
+        memory: 128Mi
+      requests:
+        cpu: 10m
+        memory: 64Mi
+  replicas: 1
+  serviceAccount:
+    annotations: {}
+  nodeSelector:
+    node-role.kubernetes.io/control-plane: ""
+  tolerations:
+  - key: node-role.kubernetes.io/master
+    operator: "Exists"
+    effect: NoSchedule
+  - key: node-role.kubernetes.io/control-plane
+    operator: "Exists"
+    effect: NoSchedule
+resourceName: ""
+nadName: dpf-ovn-kubernetes

--- a/helm/ovn-kubernetes-dpf/crds/k8s.ovn.org_adminpolicybasedexternalroutes.yaml.j2
+++ b/helm/ovn-kubernetes-dpf/crds/k8s.ovn.org_adminpolicybasedexternalroutes.yaml.j2
@@ -1,0 +1,1 @@
+../../../dist/templates/k8s.ovn.org_adminpolicybasedexternalroutes.yaml.j2

--- a/helm/ovn-kubernetes-dpf/crds/k8s.ovn.org_egressfirewalls.yaml.j2
+++ b/helm/ovn-kubernetes-dpf/crds/k8s.ovn.org_egressfirewalls.yaml.j2
@@ -1,0 +1,1 @@
+../../../dist/templates/k8s.ovn.org_egressfirewalls.yaml.j2

--- a/helm/ovn-kubernetes-dpf/crds/k8s.ovn.org_egressips.yaml.j2
+++ b/helm/ovn-kubernetes-dpf/crds/k8s.ovn.org_egressips.yaml.j2
@@ -1,0 +1,1 @@
+../../../dist/templates/k8s.ovn.org_egressips.yaml.j2

--- a/helm/ovn-kubernetes-dpf/crds/k8s.ovn.org_egressqoses.yaml.j2
+++ b/helm/ovn-kubernetes-dpf/crds/k8s.ovn.org_egressqoses.yaml.j2
@@ -1,0 +1,1 @@
+../../../dist/templates/k8s.ovn.org_egressqoses.yaml.j2

--- a/helm/ovn-kubernetes-dpf/crds/k8s.ovn.org_egressservices.yaml.j2
+++ b/helm/ovn-kubernetes-dpf/crds/k8s.ovn.org_egressservices.yaml.j2
@@ -1,0 +1,1 @@
+../../../dist/templates/k8s.ovn.org_egressservices.yaml.j2

--- a/helm/ovn-kubernetes-dpf/crds/k8s.ovn.org_userdefinednetworks.yaml.j2
+++ b/helm/ovn-kubernetes-dpf/crds/k8s.ovn.org_userdefinednetworks.yaml.j2
@@ -1,0 +1,1 @@
+../../../dist/templates/k8s.ovn.org_userdefinednetworks.yaml.j2

--- a/helm/ovn-kubernetes-dpf/crds/monitoring.coreos.com_prometheusrule.yaml
+++ b/helm/ovn-kubernetes-dpf/crds/monitoring.coreos.com_prometheusrule.yaml
@@ -1,0 +1,118 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: prometheusrules.monitoring.coreos.com
+spec:
+  group: monitoring.coreos.com
+  names:
+    categories:
+    - prometheus-operator
+    kind: PrometheusRule
+    listKind: PrometheusRuleList
+    plural: prometheusrules
+    shortNames:
+    - promrule
+    singular: prometheusrule
+  scope: Namespaced
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        description: PrometheusRule defines recording and alerting rules for a Prometheus instance
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Specification of desired alerting rule definitions for Prometheus.
+            properties:
+              groups:
+                description: Content of Prometheus rule file
+                items:
+                  description: RuleGroup is a list of sequentially evaluated recording
+                    and alerting rules.
+                  properties:
+                    interval:
+                      description: Interval determines how often rules in the group
+                        are evaluated.
+                      pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
+                      type: string
+                    limit:
+                      description: Limit the number of alerts an alerting rule and
+                        series a recording rule can produce. Limit is supported starting
+                        with Prometheus >= 2.31 and Thanos Ruler >= 0.24.
+                      type: integer
+                    name:
+                      description: Name of the rule group.
+                      minLength: 1
+                      type: string
+                    partial_response_strategy:
+                      description: 'PartialResponseStrategy is only used by ThanosRuler
+                        and will be ignored by Prometheus instances. More info: https://github.com/thanos-io/thanos/blob/main/docs/components/rule.md#partial-response'
+                      pattern: ^(?i)(abort|warn)?$
+                      type: string
+                    rules:
+                      description: List of alerting and recording rules.
+                      items:
+                        description: 'Rule describes an alerting or recording rule
+                          See Prometheus documentation: [alerting](https://www.prometheus.io/docs/prometheus/latest/configuration/alerting_rules/)
+                          or [recording](https://www.prometheus.io/docs/prometheus/latest/configuration/recording_rules/#recording-rules)
+                          rule'
+                        properties:
+                          alert:
+                            description: Name of the alert. Must be a valid label
+                              value. Only one of `record` and `alert` must be set.
+                            type: string
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            description: Annotations to add to each alert. Only valid
+                              for alerting rules.
+                            type: object
+                          expr:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: PromQL expression to evaluate.
+                            x-kubernetes-int-or-string: true
+                          for:
+                            description: Alerts are considered firing once they have
+                              been returned for this long.
+                            pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
+                            type: string
+                          labels:
+                            additionalProperties:
+                              type: string
+                            description: Labels to add or overwrite.
+                            type: object
+                          record:
+                            description: Name of the time series to output to. Must
+                              be a valid metric name. Only one of `record` and `alert`
+                              must be set.
+                            type: string
+                        required:
+                        - expr
+                        type: object
+                      type: array
+                  required:
+                  - name
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - spec
+        type: object

--- a/helm/ovn-kubernetes-dpf/crds/monitoring.coreos.com_servicemonitor.yaml
+++ b/helm/ovn-kubernetes-dpf/crds/monitoring.coreos.com_servicemonitor.yaml
@@ -1,0 +1,705 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: servicemonitors.monitoring.coreos.com
+spec:
+  group: monitoring.coreos.com
+  names:
+    categories:
+    - prometheus-operator
+    kind: ServiceMonitor
+    listKind: ServiceMonitorList
+    plural: servicemonitors
+    shortNames:
+    - smon
+    singular: servicemonitor
+  scope: Namespaced
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        description: ServiceMonitor defines monitoring for a set of services.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Specification of desired Service selection for target discovery
+              by Prometheus.
+            properties:
+              attachMetadata:
+                description: Attaches node metadata to discovered targets. Requires
+                  Prometheus v2.37.0 and above.
+                properties:
+                  node:
+                    description: When set to true, Prometheus must have permissions
+                      to get Nodes.
+                    type: boolean
+                type: object
+              endpoints:
+                description: A list of endpoints allowed as part of this ServiceMonitor.
+                items:
+                  description: Endpoint defines a scrapeable endpoint serving Prometheus
+                    metrics.
+                  properties:
+                    authorization:
+                      description: Authorization section for this endpoint
+                      properties:
+                        credentials:
+                          description: The secret's key that contains the credentials
+                            of the request
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        type:
+                          description: Set the authentication type. Defaults to Bearer,
+                            Basic will cause an error
+                          type: string
+                      type: object
+                    basicAuth:
+                      description: 'BasicAuth allow an endpoint to authenticate over
+                        basic authentication More info: https://prometheus.io/docs/operating/configuration/#endpoints'
+                      properties:
+                        password:
+                          description: The secret in the service monitor namespace
+                            that contains the password for authentication.
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        username:
+                          description: The secret in the service monitor namespace
+                            that contains the username for authentication.
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                    bearerTokenFile:
+                      description: File to read bearer token for scraping targets.
+                      type: string
+                    bearerTokenSecret:
+                      description: Secret to mount to read bearer token for scraping
+                        targets. The secret needs to be in the same namespace as the
+                        service monitor and accessible by the Prometheus Operator.
+                      properties:
+                        key:
+                          description: The key of the secret to select from.  Must
+                            be a valid secret key.
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                        optional:
+                          description: Specify whether the Secret or its key must
+                            be defined
+                          type: boolean
+                      required:
+                      - key
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    enableHttp2:
+                      description: Whether to enable HTTP2.
+                      type: boolean
+                    filterRunning:
+                      description: 'Drop pods that are not running. (Failed, Succeeded).
+                        Enabled by default. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase'
+                      type: boolean
+                    followRedirects:
+                      description: FollowRedirects configures whether scrape requests
+                        follow HTTP 3xx redirects.
+                      type: boolean
+                    honorLabels:
+                      description: HonorLabels chooses the metric's labels on collisions
+                        with target labels.
+                      type: boolean
+                    honorTimestamps:
+                      description: HonorTimestamps controls whether Prometheus respects
+                        the timestamps present in scraped data.
+                      type: boolean
+                    interval:
+                      description: Interval at which metrics should be scraped If
+                        not specified Prometheus' global scrape interval is used.
+                      pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
+                      type: string
+                    metricRelabelings:
+                      description: MetricRelabelConfigs to apply to samples before
+                        ingestion.
+                      items:
+                        description: 'RelabelConfig allows dynamic rewriting of the
+                          label set, being applied to samples before ingestion. It
+                          defines `<metric_relabel_configs>`-section of Prometheus
+                          configuration. More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs'
+                        properties:
+                          action:
+                            default: replace
+                            description: Action to perform based on regex matching.
+                              Default is 'replace'. uppercase and lowercase actions
+                              require Prometheus >= 2.36.
+                            enum:
+                            - replace
+                            - Replace
+                            - keep
+                            - Keep
+                            - drop
+                            - Drop
+                            - hashmod
+                            - HashMod
+                            - labelmap
+                            - LabelMap
+                            - labeldrop
+                            - LabelDrop
+                            - labelkeep
+                            - LabelKeep
+                            - lowercase
+                            - Lowercase
+                            - uppercase
+                            - Uppercase
+                            - keepequal
+                            - KeepEqual
+                            - dropequal
+                            - DropEqual
+                            type: string
+                          modulus:
+                            description: Modulus to take of the hash of the source
+                              label values.
+                            format: int64
+                            type: integer
+                          regex:
+                            description: Regular expression against which the extracted
+                              value is matched. Default is '(.*)'
+                            type: string
+                          replacement:
+                            description: Replacement value against which a regex replace
+                              is performed if the regular expression matches. Regex
+                              capture groups are available. Default is '$1'
+                            type: string
+                          separator:
+                            description: Separator placed between concatenated source
+                              label values. default is ';'.
+                            type: string
+                          sourceLabels:
+                            description: The source labels select values from existing
+                              labels. Their content is concatenated using the configured
+                              separator and matched against the configured regular
+                              expression for the replace, keep, and drop actions.
+                            items:
+                              description: LabelName is a valid Prometheus label name
+                                which may only contain ASCII letters, numbers, as
+                                well as underscores.
+                              pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
+                              type: string
+                            type: array
+                          targetLabel:
+                            description: Label to which the resulting value is written
+                              in a replace action. It is mandatory for replace actions.
+                              Regex capture groups are available.
+                            type: string
+                        type: object
+                      type: array
+                    oauth2:
+                      description: OAuth2 for the URL. Only valid in Prometheus versions
+                        2.27.0 and newer.
+                      properties:
+                        clientId:
+                          description: The secret or configmap containing the OAuth2
+                            client id
+                          properties:
+                            configMap:
+                              description: ConfigMap containing data to use for the
+                                targets.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secret:
+                              description: Secret containing data to use for the targets.
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        clientSecret:
+                          description: The secret containing the OAuth2 client secret
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        endpointParams:
+                          additionalProperties:
+                            type: string
+                          description: Parameters to append to the token URL
+                          type: object
+                        scopes:
+                          description: OAuth2 scopes used for the token request
+                          items:
+                            type: string
+                          type: array
+                        tokenUrl:
+                          description: The URL to fetch the token from
+                          minLength: 1
+                          type: string
+                      required:
+                      - clientId
+                      - clientSecret
+                      - tokenUrl
+                      type: object
+                    params:
+                      additionalProperties:
+                        items:
+                          type: string
+                        type: array
+                      description: Optional HTTP URL parameters
+                      type: object
+                    path:
+                      description: HTTP path to scrape for metrics. If empty, Prometheus
+                        uses the default value (e.g. `/metrics`).
+                      type: string
+                    port:
+                      description: Name of the service port this endpoint refers to.
+                        Mutually exclusive with targetPort.
+                      type: string
+                    proxyUrl:
+                      description: ProxyURL eg http://proxyserver:2195 Directs scrapes
+                        to proxy through this endpoint.
+                      type: string
+                    relabelings:
+                      description: 'RelabelConfigs to apply to samples before scraping.
+                        Prometheus Operator automatically adds relabelings for a few
+                        standard Kubernetes fields. The original scrape job''s name
+                        is available via the `__tmp_prometheus_job_name` label. More
+                        info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config'
+                      items:
+                        description: 'RelabelConfig allows dynamic rewriting of the
+                          label set, being applied to samples before ingestion. It
+                          defines `<metric_relabel_configs>`-section of Prometheus
+                          configuration. More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs'
+                        properties:
+                          action:
+                            default: replace
+                            description: Action to perform based on regex matching.
+                              Default is 'replace'. uppercase and lowercase actions
+                              require Prometheus >= 2.36.
+                            enum:
+                            - replace
+                            - Replace
+                            - keep
+                            - Keep
+                            - drop
+                            - Drop
+                            - hashmod
+                            - HashMod
+                            - labelmap
+                            - LabelMap
+                            - labeldrop
+                            - LabelDrop
+                            - labelkeep
+                            - LabelKeep
+                            - lowercase
+                            - Lowercase
+                            - uppercase
+                            - Uppercase
+                            - keepequal
+                            - KeepEqual
+                            - dropequal
+                            - DropEqual
+                            type: string
+                          modulus:
+                            description: Modulus to take of the hash of the source
+                              label values.
+                            format: int64
+                            type: integer
+                          regex:
+                            description: Regular expression against which the extracted
+                              value is matched. Default is '(.*)'
+                            type: string
+                          replacement:
+                            description: Replacement value against which a regex replace
+                              is performed if the regular expression matches. Regex
+                              capture groups are available. Default is '$1'
+                            type: string
+                          separator:
+                            description: Separator placed between concatenated source
+                              label values. default is ';'.
+                            type: string
+                          sourceLabels:
+                            description: The source labels select values from existing
+                              labels. Their content is concatenated using the configured
+                              separator and matched against the configured regular
+                              expression for the replace, keep, and drop actions.
+                            items:
+                              description: LabelName is a valid Prometheus label name
+                                which may only contain ASCII letters, numbers, as
+                                well as underscores.
+                              pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
+                              type: string
+                            type: array
+                          targetLabel:
+                            description: Label to which the resulting value is written
+                              in a replace action. It is mandatory for replace actions.
+                              Regex capture groups are available.
+                            type: string
+                        type: object
+                      type: array
+                    scheme:
+                      description: HTTP scheme to use for scraping. `http` and `https`
+                        are the expected values unless you rewrite the `__scheme__`
+                        label via relabeling. If empty, Prometheus uses the default
+                        value `http`.
+                      enum:
+                      - http
+                      - https
+                      type: string
+                    scrapeTimeout:
+                      description: Timeout after which the scrape is ended If not
+                        specified, the Prometheus global scrape timeout is used unless
+                        it is less than `Interval` in which the latter is used.
+                      pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
+                      type: string
+                    targetPort:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: Name or number of the target port of the Pod behind
+                        the Service, the port must be specified with container port
+                        property. Mutually exclusive with port.
+                      x-kubernetes-int-or-string: true
+                    tlsConfig:
+                      description: TLS configuration to use when scraping the endpoint
+                      properties:
+                        ca:
+                          description: Certificate authority used when verifying server
+                            certificates.
+                          properties:
+                            configMap:
+                              description: ConfigMap containing data to use for the
+                                targets.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secret:
+                              description: Secret containing data to use for the targets.
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        caFile:
+                          description: Path to the CA cert in the Prometheus container
+                            to use for the targets.
+                          type: string
+                        cert:
+                          description: Client certificate to present when doing client-authentication.
+                          properties:
+                            configMap:
+                              description: ConfigMap containing data to use for the
+                                targets.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secret:
+                              description: Secret containing data to use for the targets.
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        certFile:
+                          description: Path to the client cert file in the Prometheus
+                            container for the targets.
+                          type: string
+                        insecureSkipVerify:
+                          description: Disable target certificate validation.
+                          type: boolean
+                        keyFile:
+                          description: Path to the client key file in the Prometheus
+                            container for the targets.
+                          type: string
+                        keySecret:
+                          description: Secret containing the client key file for the
+                            targets.
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        serverName:
+                          description: Used to verify the hostname for the targets.
+                          type: string
+                      type: object
+                  type: object
+                type: array
+              jobLabel:
+                description: "JobLabel selects the label from the associated Kubernetes
+                  service which will be used as the `job` label for all metrics. \n
+                  For example: If in `ServiceMonitor.spec.jobLabel: foo` and in `Service.metadata.labels.foo:
+                  bar`, then the `job=\"bar\"` label is added to all metrics. \n If
+                  the value of this field is empty or if the label doesn't exist for
+                  the given Service, the `job` label of the metrics defaults to the
+                  name of the Kubernetes Service."
+                type: string
+              labelLimit:
+                description: Per-scrape limit on number of labels that will be accepted
+                  for a sample. Only valid in Prometheus versions 2.27.0 and newer.
+                format: int64
+                type: integer
+              labelNameLengthLimit:
+                description: Per-scrape limit on length of labels name that will be
+                  accepted for a sample. Only valid in Prometheus versions 2.27.0
+                  and newer.
+                format: int64
+                type: integer
+              labelValueLengthLimit:
+                description: Per-scrape limit on length of labels value that will
+                  be accepted for a sample. Only valid in Prometheus versions 2.27.0
+                  and newer.
+                format: int64
+                type: integer
+              namespaceSelector:
+                description: Selector to select which namespaces the Kubernetes Endpoints
+                  objects are discovered from.
+                properties:
+                  any:
+                    description: Boolean describing whether all namespaces are selected
+                      in contrast to a list restricting them.
+                    type: boolean
+                  matchNames:
+                    description: List of namespace names to select from.
+                    items:
+                      type: string
+                    type: array
+                type: object
+              podTargetLabels:
+                description: PodTargetLabels transfers labels on the Kubernetes `Pod`
+                  onto the created metrics.
+                items:
+                  type: string
+                type: array
+              sampleLimit:
+                description: SampleLimit defines per-scrape limit on number of scraped
+                  samples that will be accepted.
+                format: int64
+                type: integer
+              selector:
+                description: Selector to select Endpoints objects.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to
+                            a set of values. Valid operators are In, NotIn, Exists
+                            and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the
+                            operator is In or NotIn, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values
+                            array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator
+                      is "In", and the values array contains only "value". The requirements
+                      are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              targetLabels:
+                description: TargetLabels transfers labels from the Kubernetes `Service`
+                  onto the created metrics.
+                items:
+                  type: string
+                type: array
+              targetLimit:
+                description: TargetLimit defines a limit on the number of scraped
+                  targets that will be accepted.
+                format: int64
+                type: integer
+            required:
+            - endpoints
+            - selector
+            type: object
+        required:
+        - spec
+        type: object

--- a/helm/ovn-kubernetes-dpf/templates/_helpers.tpl
+++ b/helm/ovn-kubernetes-dpf/templates/_helpers.tpl
@@ -1,0 +1,51 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "ovn-kubernetes.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 50 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 40 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "ovn-kubernetes.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 40 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 40 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 40 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "ovn-kubernetes.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 50 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "ovn-kubernetes.labels" -}}
+helm.sh/chart: {{ include "ovn-kubernetes.chart" . }}
+{{ include "ovn-kubernetes.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "ovn-kubernetes.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "ovn-kubernetes.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/helm/ovn-kubernetes-dpf/templates/common.yaml
+++ b/helm/ovn-kubernetes-dpf/templates/common.yaml
@@ -1,0 +1,123 @@
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: {{ include "ovn-kubernetes.fullname" . }}-config
+  namespace: {{ .Release.Namespace }}
+data:
+  net_cidr:      {{ .Values.podNetwork }}
+  svc_cidr:      {{ .Values.serviceNetwork }}
+  k8s_apiserver: {{ .Values.k8sAPIServer }}
+  mtu:           {{ .Values.mtu | quote }}
+  host_network_namespace: "ovn-host-network"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "ovn-kubernetes.fullname" . }}-node-status-reader
+rules:
+- apiGroups: [""]
+  resources:
+  - nodes/status
+  verbs: [ "get" ]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "ovn-kubernetes.fullname" . }}-node
+rules:
+- apiGroups: [""]
+  resources:
+  - namespaces
+  - nodes
+  - pods
+  - services
+  - endpoints
+  verbs: [ "get", "list", "watch" ]
+- apiGroups: ["discovery.k8s.io"]
+  resources:
+  - endpointslices
+  verbs: [ "get", "list", "watch" ]
+- apiGroups: ["k8s.cni.cncf.io"]
+  resources:
+  - network-attachment-definitions
+  verbs: ["list", "get", "watch"]
+- apiGroups: ["networking.k8s.io"]
+  resources:
+  - networkpolicies
+  verbs: [ "get", "list", "watch" ]
+- apiGroups: ["k8s.cni.cncf.io"]
+  resources:
+  - ipamclaims
+  - multi-networkpolicies
+  verbs: ["list", "get", "watch"]
+- apiGroups: [ "k8s.cni.cncf.io" ]
+  resources:
+  - ipamclaims/status
+  verbs: [ "patch", "update" ]
+- apiGroups: ["k8s.ovn.org"]
+  resources:
+  - egressfirewalls/status
+  - adminpolicybasedexternalroutes/status
+  - egressqoses/status
+  verbs: [ "patch", "update" ]
+- apiGroups: ["policy.networking.k8s.io"]
+  resources:
+  - adminnetworkpolicies/status
+  - baselineadminnetworkpolicies/status
+  verbs: [ "patch", "update" ]
+- apiGroups: ["policy.networking.k8s.io"]
+  resources:
+  - adminnetworkpolicies
+  - baselineadminnetworkpolicies
+  verbs: ["list", "get", "watch"]
+- apiGroups: ["k8s.ovn.org"]
+  resources:
+  - egressfirewalls
+  - egressips
+  - egressqoses
+  - egressservices
+  - adminpolicybasedexternalroutes
+  verbs: [ "get", "list", "watch" ]
+- apiGroups: [""]
+  resources:
+  - events
+  verbs: ["create", "patch", "update"]
+- apiGroups: [""]
+  resources:
+  - namespaces/status
+  - pods/status
+  - nodes/status
+  verbs: [ "patch", "update" ]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "ovn-kubernetes.fullname" . }}-configmaps
+  namespace: {{ .Release.Namespace }}
+rules:
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["get", "watch", "list"]
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - get
+  - list
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "ovn-kubernetes.fullname" . }}-endpoints
+  namespace: {{ .Release.Namespace }}
+rules:
+- apiGroups: [""]
+  resources:
+  - endpoints
+  verbs:
+  - get
+  - create

--- a/helm/ovn-kubernetes-dpf/templates/control-plane-manifests.yaml
+++ b/helm/ovn-kubernetes-dpf/templates/control-plane-manifests.yaml
@@ -1,0 +1,348 @@
+{{- if .Values.controlPlaneManifests.enabled }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "ovn-kubernetes.fullname" . }}-cluster-manager
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "ovn-kubernetes.fullname" . }}-cluster-manager
+rules:
+- apiGroups: [""]
+  resources:
+  - namespaces
+  - nodes
+  - pods
+  - services
+  - endpoints
+  verbs: [ "get", "list", "watch" ]
+- apiGroups: ["discovery.k8s.io"]
+  resources:
+  - endpointslices
+  verbs: [ "get", "list", "watch" ]
+- apiGroups: ["k8s.cni.cncf.io"]
+  resources:
+  - ipamclaims
+  - network-attachment-definitions
+  - multi-networkpolicies
+  verbs: ["list", "get", "watch"]
+- apiGroups: [ "k8s.cni.cncf.io" ]
+  resources:
+  - ipamclaims/status
+  - network-attachment-definitions
+  verbs: [ "patch", "update" ]
+- apiGroups: [ "k8s.cni.cncf.io" ]
+  resources:
+  - network-attachment-definitions
+  verbs: [ "create", "delete" ]
+- apiGroups: ["k8s.ovn.org"]
+  resources:
+  - egressips
+  - egressservices
+  - adminpolicybasedexternalroutes
+  - egressfirewalls
+  - egressqoses
+  - userdefinednetworks
+  verbs: [ "get", "list", "watch" ]
+- apiGroups: ["k8s.ovn.org"]
+  resources:
+  - egressips
+  - egressservices/status
+  - userdefinednetworks
+  - userdefinednetworks/status
+  verbs: [ "patch", "update" ]
+- apiGroups: [""]
+  resources:
+  - events
+  verbs: ["create", "patch", "update"]
+- apiGroups: [""]
+  resources:
+  - pods/status
+  - nodes/status
+  - services/status
+  verbs: [ "patch", "update" ]
+- apiGroups: ["k8s.ovn.org"]
+  resources:
+  - adminpolicybasedexternalroutes/status
+  - egressfirewalls/status
+  - egressqoses/status
+  verbs: [ "patch", "update" ]
+- apiGroups: ["policy.networking.k8s.io"]
+  resources:
+  - adminnetworkpolicies
+  - baselineadminnetworkpolicies
+  verbs: [ "list" ]
+- apiGroups: ["policy.networking.k8s.io"]
+  resources:
+  - adminnetworkpolicies/status
+  - baselineadminnetworkpolicies/status
+  verbs: [ "patch" ]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "ovn-kubernetes.fullname" . }}-cluster-manager
+roleRef:
+  name: {{ include "ovn-kubernetes.fullname" . }}-cluster-manager
+  kind: ClusterRole
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: {{ include "ovn-kubernetes.fullname" . }}-cluster-manager
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "ovn-kubernetes.fullname" . }}-configmaps
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  name: {{ include "ovn-kubernetes.fullname" . }}-configmaps
+  kind: Role
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: {{ include "ovn-kubernetes.fullname" . }}-cluster-manager
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: ovnkube-cluster-manager
+  name: {{ include "ovn-kubernetes.fullname" . }}-cm-prometheus
+  namespace: {{ .Release.Namespace }}
+spec:
+  selector:
+    app.kubernetes.io/component: ovnkube-cluster-manager
+    {{- include "ovn-kubernetes.selectorLabels" . | nindent 4 }}
+  type: ClusterIP
+  clusterIP: None
+  publishNotReadyAddresses: true
+  ports:
+  - name: http-metrics
+    port: 9411
+    protocol: TCP
+    targetPort: 9411
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: {{ include "ovn-kubernetes.fullname" . }}-cluster-manager
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    kubernetes.io/description: |
+      This Deployment launches the ovn-kubernetes cluster manager networking component.
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: ovnkube-cluster-manager
+      {{- include "ovn-kubernetes.selectorLabels" . | nindent 6 }}
+  strategy:
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: ovnkube-cluster-manager
+        {{- include "ovn-kubernetes.selectorLabels" . | nindent 8 }}
+        kubernetes.io/os: "linux"
+        ovn.dpu.nvidia.com/skip-injection: ""
+    spec:
+      {{- if .Values.imagePullSecretName }}
+      imagePullSecrets:
+      - name: {{ .Values.imagePullSecretName }}
+      {{- end }}
+      priorityClassName: "system-cluster-critical"
+      serviceAccountName: {{ include "ovn-kubernetes.fullname" . }}-cluster-manager
+      hostNetwork: true
+      dnsPolicy: Default
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                - linux
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app.kubernetes.io/component
+                operator: In
+                values:
+                - ovnkube-cluster-manager
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - name: ovnkube-cluster-manager
+        image: {{ .Values.controlPlaneManifests.image.repository }}:{{ .Values.controlPlaneManifests.image.tag }}
+        imagePullPolicy: {{ .Values.controlPlaneManifests.image.pullPolicy }}
+        command: ["/root/ovnkube.sh", "ovn-cluster-manager"]
+        securityContext:
+          runAsUser: 0
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /var/run/dbus/
+          name: host-var-run-dbus
+          readOnly: true
+        - mountPath: /var/log/ovn-kubernetes/
+          name: host-var-log-ovnkube
+        - mountPath: /var/run/openvswitch/
+          name: host-var-run-ovs
+        - mountPath: /var/run/ovn/
+          name: host-var-run-ovs
+        - mountPath: /ovn-cert
+          name: host-ovn-cert
+          readOnly: true
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+        env:
+        - name: OVN_DAEMONSET_VERSION
+          value: "1.0.0"
+        - name: OVNKUBE_LOGLEVEL
+          value: "4"
+        - name: OVNKUBE_LOGFILE_MAXSIZE
+          value: "100"
+        - name: OVNKUBE_LOGFILE_MAXBACKUPS
+          value: "5"
+        - name: OVNKUBE_LOGFILE_MAXAGE
+          value: "5"
+        - name: OVNKUBE_CONFIG_DURATION_ENABLE
+          value: ""
+        - name: OVN_NET_CIDR
+          valueFrom:
+            configMapKeyRef:
+              name: {{ include "ovn-kubernetes.fullname" . }}-config
+              key: net_cidr
+        - name: OVN_SVC_CIDR
+          valueFrom:
+            configMapKeyRef:
+              name: {{ include "ovn-kubernetes.fullname" . }}-config
+              key: svc_cidr
+        - name: K8S_APISERVER
+          valueFrom:
+            configMapKeyRef:
+              name: {{ include "ovn-kubernetes.fullname" . }}-config
+              key: k8s_apiserver
+        - name: K8S_NODE
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: K8S_NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OVN_KUBERNETES_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: OVN_HYBRID_OVERLAY_ENABLE
+          value: ""
+        - name: OVN_ADMIN_NETWORK_POLICY_ENABLE
+          value: ""
+        - name: OVN_EGRESSIP_ENABLE
+          value: ""
+        - name: OVN_EGRESSSERVICE_ENABLE
+          value: ""
+        - name: OVN_EGRESSFIREWALL_ENABLE
+          value: ""
+        - name: OVN_EGRESSQOS_ENABLE
+          value: ""
+        - name: OVN_MULTI_NETWORK_ENABLE
+          value: "false"
+        - name: OVN_HYBRID_OVERLAY_NET_CIDR
+          value: ""
+        - name: OVN_DISABLE_SNAT_MULTIPLE_GWS
+          value: ""
+        - name: OVN_EMPTY_LB_EVENTS
+          value: ""
+        - name: OVN_V4_JOIN_SUBNET
+          value: "100.64.0.0/16"
+        - name: OVN_V6_JOIN_SUBNET
+          value: "fd98::/64"
+        - name: OVN_SSL_ENABLE
+          value: "false"
+        - name: OVN_GATEWAY_MODE
+          value: shared
+        - name: OVN_MULTICAST_ENABLE
+          value: ""
+        - name: OVN_ACL_LOGGING_RATE_LIMIT
+          value: "20"
+        - name: OVN_STATELESS_NETPOL_ENABLE
+          value: "true"
+        - name: OVN_HOST_NETWORK_NAMESPACE
+          valueFrom:
+            configMapKeyRef:
+              name: {{ include "ovn-kubernetes.fullname" . }}-config
+              key: host_network_namespace
+        - name: OVN_ENABLE_INTERCONNECT
+          value: "true"
+        - name: OVN_ENABLE_MULTI_EXTERNAL_GATEWAY
+          value: "false"
+        - name: OVN_V4_TRANSIT_SWITCH_SUBNET
+          value: "100.88.0.0/16"
+        - name: OVN_V6_TRANSIT_SWITCH_SUBNET
+          value: "fd97::/64"
+        - name: OVN_ENABLE_PERSISTENT_IPS
+          value: "false"
+        - name: OVN_ENABLE_DNSNAMERESOLVER
+          value: "false"
+        - name: OVN_NOHOSTSUBNET_LABEL
+          value: "k8s.ovn.org/ovn-managed=false"
+      volumes:
+      - name: host-var-run-dbus
+        hostPath:
+          path: /var/run/dbus
+      - name: host-var-log-ovs
+        hostPath:
+          path: /var/log/openvswitch
+      - name: host-var-log-ovnkube
+        hostPath:
+          path: /var/log/ovn-kubernetes
+      - name: host-var-run-ovs
+        hostPath:
+          path: /var/run/openvswitch
+      - name: host-ovn-cert
+        hostPath:
+          path: /etc/ovn
+          type: DirectoryOrCreate
+      tolerations:
+      - operator: "Exists"
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app.kubernetes.io/component: ovnkube-cluster-manager
+  name: {{ include "ovn-kubernetes.fullname" . }}-cm-prometheus
+  namespace: {{ .Release.Namespace }}
+spec:
+  endpoints:
+  - interval: 30s
+    port: http-metrics
+    scheme: http
+    path: /metrics
+  jobLabel: k8s-app
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: ovnkube-cluster-manager
+      {{- include "ovn-kubernetes.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/helm/ovn-kubernetes-dpf/templates/dpu-manifests.yaml
+++ b/helm/ovn-kubernetes-dpf/templates/dpu-manifests.yaml
@@ -1,0 +1,906 @@
+{{- if .Values.dpuManifests.enabled }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "ovn-kubernetes.fullname" . }}-dpucniprovisioner
+  namespace: {{ .Release.Namespace }}
+automountServiceAccountToken: false
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "ovn-kubernetes.fullname" . }}-node
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "ovn-kubernetes.fullname" . }}-dpucniprovisioner-token
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    kubernetes.io/service-account.name: {{ include "ovn-kubernetes.fullname" . }}-dpucniprovisioner
+type: kubernetes.io/service-account-token
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "ovn-kubernetes.fullname" . }}-dpucniprovisioner
+rules:
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["get", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "ovn-kubernetes.fullname" . }}-dpucniprovisioner
+subjects:
+- kind: ServiceAccount
+  name: {{ include "ovn-kubernetes.fullname" . }}-dpucniprovisioner
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ include "ovn-kubernetes.fullname" . }}-dpucniprovisioner
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "ovn-kubernetes.fullname" . }}-node
+roleRef:
+  name: {{ include "ovn-kubernetes.fullname" . }}-node
+  kind: ClusterRole
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: {{ include "ovn-kubernetes.fullname" . }}-node
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "ovn-kubernetes.fullname" . }}-node-status-reader
+roleRef:
+  name: {{ include "ovn-kubernetes.fullname" . }}-node-status-reader
+  kind: ClusterRole
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: {{ include "ovn-kubernetes.fullname" . }}-node
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "ovn-kubernetes.fullname" . }}-configmaps
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  name: {{ include "ovn-kubernetes.fullname" . }}-configmaps
+  kind: Role
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: {{ include "ovn-kubernetes.fullname" . }}-node
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "ovn-kubernetes.fullname" . }}-endpoints
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  name: {{ include "ovn-kubernetes.fullname" . }}-endpoints
+  kind: Role
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: {{ include "ovn-kubernetes.fullname" . }}-node
+  namespace: {{ .Release.Namespace }}
+---
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: {{ include "ovn-kubernetes.fullname" . }}-node
+  namespace: {{ .Release.Namespace }}
+  {{- with .Values.serviceDaemonSet.labels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  annotations:
+    {{- with .Values.serviceDaemonSet.annotations }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+    kubernetes.io/description: |
+      This DaemonSet launches the ovn-kubernetes networking components for worker nodes.
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: ovnkube-node
+      {{- include "ovn-kubernetes.selectorLabels" . | nindent 6 }}
+      {{- with .Values.serviceDaemonSet.labels }}
+        {{- toYaml . | nindent 6 }}
+      {{- end }}
+  {{- with .Values.serviceDaemonSet.updateStrategy }}
+  updateStrategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: ovnkube-node
+        {{- include "ovn-kubernetes.selectorLabels" . | nindent 8 }}
+        kubernetes.io/os: "linux"
+        {{- with .Values.serviceDaemonSet.labels }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- if or (not .Values.dpuManifests.externalDHCP) .Values.serviceDaemonSet.annotations }}
+      annotations:
+        {{- with .Values.serviceDaemonSet.annotations }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- if not .Values.dpuManifests.externalDHCP }}
+        dpf.nvidia.com/ip-requests: |-
+          [
+            {
+              "name": "vtep",
+              "poolName": "{{ .Values.dpuManifests.ipamPool }}",
+              "poolType": "{{ .Values.dpuManifests.ipamPoolType}}",
+              "allocateIPWithIndex": {{ .Values.dpuManifests.ipamVTEPIPIndex }}
+            },
+            {
+              "name": "pf",
+              "poolName": "{{ .Values.dpuManifests.ipamPool }}",
+              "poolType": "{{ .Values.dpuManifests.ipamPoolType}}",
+              "allocateIPWithIndex": {{ .Values.dpuManifests.ipamPFIPIndex }}
+            }
+          ]
+        {{- end }}
+      {{- end }}
+    spec:
+      {{- with .Values.serviceDaemonSet.nodeSelector }}
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+              {{- toYaml . | nindent 12 }}
+      {{- end }}
+      {{- if .Values.imagePullSecretName }}
+      imagePullSecrets:
+      - name: {{ .Values.imagePullSecretName }}
+      {{- end }}
+      priorityClassName: "system-cluster-critical"
+      serviceAccountName: {{ include "ovn-kubernetes.fullname" . }}-node
+      hostNetwork: true
+      dnsPolicy: Default
+      hostPID: true
+      automountServiceAccountToken: false
+      # DPU CNI provisioner
+      initContainers:
+      {{- if not .Values.dpuManifests.externalDHCP }}
+      - name: ipallocator
+        image: {{ .Values.dpuManifests.image.repository }}:{{ .Values.dpuManifests.image.tag }}
+        imagePullPolicy: {{ .Values.dpuManifests.image.pullPolicy }}
+        command:
+        - /ipallocator
+        - allocator
+        # Needs to always run so that later it can receive a signal to do a CMD DEL
+        restartPolicy: Always
+        securityContext:
+          # Needs to run as root to ensure that it can access the NVIPAM socket
+          runAsUser: 0
+        readinessProbe:
+          exec:
+            command:
+            - cat
+            - /var/run/readyz
+        # Startup probe is not really nessecary but it helps ensure that the file is written before the real app container
+        # starts.
+        startupProbe:
+          exec:
+            command:
+            - cat
+            - /var/run/readyz
+        # We use preStop to deallocate the IP when the pod is deleted. Quoting the official docs:
+        # PreStop is called immediately before a container is terminated due to an
+        # API request or management event such as liveness/startup probe failure,
+        # preemption, resource contention, etc. The handler is not called if the
+        # container crashes or exits.
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /ipallocator
+              - deallocator
+        env:
+        - name: IP_ALLOCATOR_REQUESTS
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.annotations['dpf.nvidia.com/ip-requests']
+        - name: K8S_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: K8S_POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: K8S_POD_UID
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
+        volumeMounts:
+        - mountPath: /opt/cni/bin
+          name: cni-bin-dir
+          readOnly: true
+        - mountPath: /var/lib/cni/nv-ipam
+          name: nvipam-daemon-socket-dir
+          readOnly: true
+        - mountPath: /tmp/ips
+          name: ips
+        # Used for caching the result
+        - mountPath: /var/lib/cni
+          name: cni-cache
+      {{- end }}
+      - name: cniprovisioner
+        image: {{ .Values.dpuManifests.image.repository }}:{{ .Values.dpuManifests.image.tag }}
+        imagePullPolicy: {{ .Values.dpuManifests.image.pullPolicy }}
+        command: ["/cniprovisioner"]
+        args:
+        {{- if .Values.dpuManifests.externalDHCP }}
+        - external-ipam
+        {{- else }}
+        - internal-ipam
+        {{- end }}
+        # Needs to always run because of DHCP server
+        restartPolicy: Always
+        # Ensures that DHCP server is up and running. This is for serving IP to the PF on the host.
+        readinessProbe:
+          exec:
+            command:
+            - cat
+            - /var/run/readyz
+        # Needed to ensure that the configuration finishes before the rest of the containers start
+        startupProbe:
+          exec:
+            command:
+            - cat
+            - /var/run/readyz
+          initialDelaySeconds: 30
+        securityContext:
+          privileged: true
+          runAsUser: 0
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        {{- if .Values.dpuManifests.externalDHCP }}
+        # Needed so that systemctl can run inside the container
+        - name: SYSTEMCTL_FORCE_BUS
+          value: "1"
+        # Needed so that systemctl called via netplan doesn't do noop actions
+        - name: SYSTEMD_OFFLINE
+          value: "0"
+        # Needed so that udevadm called via systemctl called via netplan doesn't do noop actions. Although deprecated,
+        # this is what it's in use. The new env variable SYSTEMD_IN_CHROOT doesn't work.
+        - name: SYSTEMD_IGNORE_CHROOT
+          value: "1"
+        - name: GATEWAY_DISCOVERY_NETWORK
+          value: {{ default "" .Values.dpuManifests.gatewayDiscoveryNetwork | quote }}
+        {{- else }}
+        - name: VTEP_CIDR
+          value: {{ default "" .Values.dpuManifests.vtepCIDR | quote }}
+        - name: OVN_MTU
+          valueFrom:
+            configMapKeyRef:
+              name: {{ include "ovn-kubernetes.fullname" . }}-config
+              key: mtu
+        {{- end }}
+        - name: HOST_CIDR
+          value: {{ default "" .Values.dpuManifests.hostCIDR | quote }}
+        volumeMounts:
+        {{- if .Values.dpuManifests.externalDHCP }}
+        # Needed so that we can write netplan config files
+        - mountPath: /etc/netplan
+          name: netplan
+        # Needed so that netplan apply writes systemd networkd config files to host path
+        - name: run-systemd
+          mountPath: /run/systemd
+        # Needed so that netplan apply can restart systemd services
+        - name: systemd-dbus
+          mountPath: /var/run/dbus/system_bus_socket
+        # Needed so that netplan apply can run udevadm reload
+        - mountPath: /run/udev
+          name: run-udev
+        # Needed so that netplan apply uses the MACAddressPolicy of the system instead of the image one
+        # which leads to a conflicting MAC addresses across nodes
+        - mountPath: /usr/lib/systemd/network
+          name: usr-lib-systemd-network
+        {{- else }}
+        - mountPath: /tmp/ips
+          name: ips
+        {{- end }}
+        - mountPath: /etc/init-output
+          name: init-output
+        - name: incluster
+          mountPath: "/var/run/secrets/kubernetes.io/serviceaccount"
+          readOnly: true
+        - mountPath: /var/run/openvswitch/
+          name: host-var-run-ovs
+      containers:
+      - name: nb-ovsdb
+        image: {{ .Values.dpuManifests.image.repository }}:{{ .Values.dpuManifests.image.tag }}
+        imagePullPolicy: {{ .Values.dpuManifests.image.pullPolicy }}
+        command: ["/root/ovnkube.sh", "local-nb-ovsdb"]
+        securityContext:
+          runAsUser: 0
+          capabilities:
+            add: ["NET_ADMIN"]
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /etc/openvswitch/
+          name: host-etc-ovs
+        - mountPath: /etc/ovn/
+          name: host-var-lib-ovs
+        - mountPath: /var/log/openvswitch/
+          name: host-var-log-ovs
+        - mountPath: /var/log/ovn/
+          name: host-var-log-ovs
+        - mountPath: /ovn-cert
+          name: host-ovn-cert
+          readOnly: true
+        - mountPath: /var/run/ovn/
+          name: host-var-run-ovs
+        - mountPath: /var/run/openvswitch/
+          name: host-var-run-ovs
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+        env:
+        - name: OVN_DAEMONSET_VERSION
+          value: "1.0.0"
+        - name: OVN_LOGLEVEL_NB
+          value: "-vconsole:info -vfile:info"
+        - name: K8S_APISERVER
+          valueFrom:
+            configMapKeyRef:
+              name: {{ include "ovn-kubernetes.fullname" . }}-config
+              key: k8s_apiserver
+        - name: OVN_KUBERNETES_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: K8S_NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: K8S_NODE
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        readinessProbe:
+          exec:
+            command: ["/usr/bin/ovn-kube-util", "readiness-probe", "-t", "ovnnb-db"]
+          initialDelaySeconds: 30
+          timeoutSeconds: 30
+          periodSeconds: 60
+      - name: sb-ovsdb
+        image: {{ .Values.dpuManifests.image.repository }}:{{ .Values.dpuManifests.image.tag }}
+        imagePullPolicy: {{ .Values.dpuManifests.image.pullPolicy }}
+        command: ["/root/ovnkube.sh", "local-sb-ovsdb"]
+        securityContext:
+          runAsUser: 0
+          capabilities:
+            add: ["NET_ADMIN"]
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /etc/openvswitch/
+          name: host-etc-ovs
+        - mountPath: /etc/ovn/
+          name: host-var-lib-ovs
+        - mountPath: /var/log/openvswitch/
+          name: host-var-log-ovs
+        - mountPath: /var/log/ovn/
+          name: host-var-log-ovs
+        - mountPath: /ovn-cert
+          name: host-ovn-cert
+          readOnly: true
+        - mountPath: /var/run/ovn/
+          name: host-var-run-ovs
+        - mountPath: /var/run/openvswitch/
+          name: host-var-run-ovs
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+        env:
+        - name: OVN_DAEMONSET_VERSION
+          value: "1.0.0"
+        - name: OVN_LOGLEVEL_SB
+          value: "-vconsole:info -vfile:info"
+        - name: K8S_APISERVER
+          valueFrom:
+            configMapKeyRef:
+              name: {{ include "ovn-kubernetes.fullname" . }}-config
+              key: k8s_apiserver
+        - name: OVN_KUBERNETES_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: K8S_NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: K8S_NODE
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: OVN_SSL_ENABLE
+          value: "no"
+        readinessProbe:
+          exec:
+            command: ["/usr/bin/ovn-kube-util", "readiness-probe", "-t", "ovnsb-db"]
+          initialDelaySeconds: 30
+          timeoutSeconds: 30
+          periodSeconds: 60
+      - name: ovn-northd
+        image: {{ .Values.dpuManifests.image.repository }}:{{ .Values.dpuManifests.image.tag }}
+        imagePullPolicy: {{ .Values.dpuManifests.image.pullPolicy }}
+        command: ["/root/ovnkube.sh", "run-ovn-northd"]
+        securityContext:
+          runAsUser: 0
+          capabilities:
+            add: ["SYS_NICE"]
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /var/run/dbus/
+          name: host-var-run-dbus
+          readOnly: true
+        - mountPath: /var/log/openvswitch/
+          name: host-var-log-ovs
+        - mountPath: /var/log/ovn/
+          name: host-var-log-ovs
+        - mountPath: /var/run/openvswitch/
+          name: host-var-run-ovs
+        - mountPath: /var/run/ovn/
+          name: host-var-run-ovs
+        - mountPath: /ovn-cert
+          name: host-ovn-cert
+          readOnly: true
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+        env:
+        - name: OVN_DAEMONSET_VERSION
+          value: "1.0.0"
+        - name: OVN_LOGLEVEL_NORTHD
+          value: "-vconsole:info -vfile:info"
+        - name: K8S_APISERVER
+          valueFrom:
+            configMapKeyRef:
+              name: {{ include "ovn-kubernetes.fullname" . }}-config
+              key: k8s_apiserver
+        - name: OVN_KUBERNETES_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: OVN_SSL_ENABLE
+          value: "no"
+        - name: OVN_NORTH
+          value: "local"
+        - name: OVN_SOUTH
+          value: "local"
+        readinessProbe:
+          exec:
+            command: ["/usr/bin/ovn-kube-util", "readiness-probe", "-t", "ovn-northd"]
+          initialDelaySeconds: 30
+          timeoutSeconds: 30
+          periodSeconds: 60
+      - name: doca-ovnkube-controller
+        image: {{ .Values.dpuManifests.image.repository }}:{{ .Values.dpuManifests.image.tag }}
+        imagePullPolicy: {{ .Values.dpuManifests.image.pullPolicy }}
+        command: ["/root/ovnkube.sh", "ovnkube-controller-with-node"]
+        securityContext:
+          runAsUser: 0
+          privileged: true
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /etc/init-output
+          name: init-output
+        - mountPath: /host
+          name: host-slash
+          readOnly: true
+        - mountPath: /var/lib/kubelet
+          name: host-kubelet
+          readOnly: true
+        - mountPath: /host-kubernetes
+          name: host-kubeconfig
+          readOnly: true
+        - mountPath: /var/run/dbus/
+          name: host-var-run-dbus
+          readOnly: true
+        - mountPath: /var/log/ovn-kubernetes/
+          name: host-var-log-ovnkube
+        - mountPath: /var/run/ovn-kubernetes
+          name: host-var-run-ovn-kubernetes
+        # CNI related mounts which we take over
+        - mountPath: /opt/cni/bin
+          name: host-opt-cni-bin
+        - mountPath: /etc/cni/net.d
+          name: host-etc-cni-netd
+        - mountPath: /var/run/netns
+          name: host-netns
+          mountPropagation: Bidirectional
+        - mountPath: /var/run/openvswitch/
+          name: host-var-run-ovs
+        - mountPath: /var/run/ovn/
+          name: host-var-run-ovs
+        - mountPath: /ovn-cert
+          name: host-ovn-cert
+          readOnly: true
+        - mountPath: /etc/openvswitch/
+          name: host-etc-ovs
+          readOnly: true
+        - mountPath: /etc/ovn/
+          name: host-var-lib-ovs
+          readOnly: true
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: tenant-cluster-access-secret
+          readOnly: true
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+        env:
+        - name: OVN_EGRESSSERVICE_ENABLE
+          value: ""
+        - name: OVN_DAEMONSET_VERSION
+          value: "1.0.0"
+        - name: OVNKUBE_LOGLEVEL
+          value: "4"
+        - name: OVNKUBE_LOGFILE_MAXSIZE
+          value: "100"
+        - name: OVNKUBE_LOGFILE_MAXBACKUPS
+          value: "5"
+        - name: OVNKUBE_LOGFILE_MAXAGE
+          value: "5"
+        - name: OVNKUBE_LIBOVSDB_CLIENT_LOGFILE
+          value: ""
+        - name: OVNKUBE_CONFIG_DURATION_ENABLE
+          value: ""
+        - name: OVNKUBE_METRICS_SCALE_ENABLE
+          value: ""
+        - name: OVN_GATEWAY_ROUTER_SUBNET
+          value: ""
+        - name: OVN_NET_CIDR
+          valueFrom:
+            configMapKeyRef:
+              name: {{ include "ovn-kubernetes.fullname" . }}-config
+              key: net_cidr
+        - name: OVN_SVC_CIDR
+          valueFrom:
+            configMapKeyRef:
+              name: {{ include "ovn-kubernetes.fullname" . }}-config
+              key: svc_cidr
+        - name: K8S_APISERVER
+          valueFrom:
+            configMapKeyRef:
+              name: {{ include "ovn-kubernetes.fullname" . }}-config
+              key: k8s_apiserver
+        - name: OVN_MTU
+          valueFrom:
+            configMapKeyRef:
+              name: {{ include "ovn-kubernetes.fullname" . }}-config
+              key: mtu
+        - name: OVN_ROUTABLE_MTU
+          valueFrom:
+            configMapKeyRef:
+              name: {{ include "ovn-kubernetes.fullname" . }}-config
+              key: routable_mtu
+              optional: true
+        - name: K8S_NODE
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: K8S_NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OVN_KUBERNETES_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: OVN_GATEWAY_MODE
+          value: shared
+        - name: OVN_GATEWAY_OPTS
+          value: {{ default "" .Values.gatewayOpts | quote }}
+        - name: OVN_HYBRID_OVERLAY_ENABLE
+          value: ""
+        - name: OVN_ADMIN_NETWORK_POLICY_ENABLE
+          value: ""
+        - name: OVN_EGRESSIP_ENABLE
+          value: ""
+        - name: OVN_EGRESSIP_HEALTHCHECK_PORT
+          value: "9107"
+        - name: OVN_EGRESSFIREWALL_ENABLE
+          value: ""
+        - name: OVN_EGRESSQOS_ENABLE
+          value: ""
+        - name: OVN_HYBRID_OVERLAY_NET_CIDR
+          value: ""
+        - name: OVN_DISABLE_SNAT_MULTIPLE_GWS
+          value: ""
+        - name: OVN_DISABLE_FORWARDING
+          value: ""
+        - name: OVN_ENCAP_PORT
+          value: "6081"
+        - name: OVN_DISABLE_PKT_MTU_CHECK
+          value: ""
+        - name: OVN_NETFLOW_TARGETS
+          value: ""
+        - name: OVN_SFLOW_TARGETS
+          value: ""
+        - name: OVN_IPFIX_TARGETS
+          value: ""
+        - name: OVN_IPFIX_SAMPLING
+          value: ""
+        - name: OVN_IPFIX_CACHE_MAX_FLOWS
+          value: ""
+        - name: OVN_IPFIX_CACHE_ACTIVE_TIMEOUT
+          value: ""
+        - name: OVN_V4_JOIN_SUBNET
+          value: "100.64.0.0/16"
+        - name: OVN_V6_JOIN_SUBNET
+          value: "fd98::/64"
+        - name: OVN_V4_MASQUERADE_SUBNET
+          value: "169.254.0.0/17"
+        - name: OVN_V6_MASQUERADE_SUBNET
+          value: "fd69::/112"
+        - name: OVN_MULTICAST_ENABLE
+          value: ""
+        - name: OVN_UNPRIVILEGED_MODE
+          value: "no"
+        - name: OVN_EX_GW_NETWORK_INTERFACE
+          value: ""
+        - name: OVN_SSL_ENABLE
+          value: "no"
+        - name: OVN_DISABLE_OVN_IFACE_ID_VER
+          value: "false"
+        - name: OVN_REMOTE_PROBE_INTERVAL
+          value: "100000"
+        - name: OVN_MONITOR_ALL
+          value: ""
+        - name: OVN_OFCTRL_WAIT_BEFORE_CLEAR
+          value: ""
+        - name: OVN_ENABLE_LFLOW_CACHE
+          value: "false"
+        - name: OVN_LFLOW_CACHE_LIMIT
+          value: ""
+        - name: OVN_LFLOW_CACHE_LIMIT_KB
+          value: ""
+        - name: OVN_MULTI_NETWORK_ENABLE
+          value: "false"
+        - name: OVN_EMPTY_LB_EVENTS
+          value: ""
+        - name: OVN_ACL_LOGGING_RATE_LIMIT
+          value: "20"
+        - name: OVN_STATELESS_NETPOL_ENABLE
+          value: "true"
+        - name: OVN_HOST_NETWORK_NAMESPACE
+          valueFrom:
+            configMapKeyRef:
+              name: {{ include "ovn-kubernetes.fullname" . }}-config
+              key: host_network_namespace
+        - name: OVN_NORTH
+          value: "local"
+        - name: OVN_SOUTH
+          value: "local"
+        - name: OVN_ENABLE_INTERCONNECT
+          value: "true"
+        - name: OVN_ENABLE_MULTI_EXTERNAL_GATEWAY
+          value: "false"
+        - name: OVN_ENABLE_OVNKUBE_IDENTITY
+          value: "false"
+        - name: OVN_ENABLE_SVC_TEMPLATE_SUPPORT
+          value: "false"
+        - name: OVN_ENABLE_DNSNAMERESOLVER
+          value: "false"
+        - name: OVN_NOHOSTSUBNET_LABEL
+          value: "k8s.ovn.org/ovn-managed=false"
+        - name: OVNKUBE_NODE_MODE
+          value: "dpu"
+        readinessProbe:
+          exec:
+            command: ["/usr/bin/ovn-kube-util", "readiness-probe", "-t", "ovnkube-node"]
+          initialDelaySeconds: 30
+          timeoutSeconds: 30
+          periodSeconds: 60
+      - name: ovn-controller
+        image: {{ .Values.dpuManifests.image.repository }}:{{ .Values.dpuManifests.image.tag }}
+        imagePullPolicy: {{ .Values.dpuManifests.image.pullPolicy }}
+        command: ["/root/ovnkube.sh", "ovn-controller"]
+        securityContext:
+          runAsUser: 0
+          capabilities:
+            add: ["SYS_NICE"]
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /var/run/dbus/
+          name: host-var-run-dbus
+          readOnly: true
+        - mountPath: /var/log/openvswitch/
+          name: host-var-log-ovs
+        - mountPath: /var/log/ovn/
+          name: host-var-log-ovs
+        - mountPath: /var/run/openvswitch/
+          name: host-var-run-ovs
+        - mountPath: /var/run/ovn/
+          name: host-var-run-ovs
+        - mountPath: /ovn-cert
+          name: host-ovn-cert
+          readOnly: true
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+        env:
+        - name: OVN_DAEMONSET_VERSION
+          value: "1.0.0"
+        - name: OVN_LOGLEVEL_CONTROLLER
+          value: "-vconsole:info"
+        - name: K8S_APISERVER
+          valueFrom:
+            configMapKeyRef:
+              name: {{ include "ovn-kubernetes.fullname" . }}-config
+              key: k8s_apiserver
+        - name: OVN_KUBERNETES_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: OVN_SSL_ENABLE
+          value: ""
+        - name: OVN_NORTH
+          value: "local"
+        - name: OVN_SOUTH
+          value: "local"
+        readinessProbe:
+          exec:
+            command: ["/usr/bin/ovn-kube-util", "readiness-probe", "-t", "ovn-controller"]
+          initialDelaySeconds: 30
+          timeoutSeconds: 30
+          periodSeconds: 60
+      - name: ovs-metrics-exporter
+        image: {{ .Values.dpuManifests.image.repository }}:{{ .Values.dpuManifests.image.tag }}
+        imagePullPolicy: {{ .Values.dpuManifests.image.pullPolicy }}
+        command: ["/root/ovnkube.sh", "ovs-metrics"]
+        securityContext:
+          runAsUser: 0
+          capabilities:
+            add: ["NET_ADMIN"]
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /var/run/dbus/
+          name: host-var-run-dbus
+          readOnly: true
+        - mountPath: /var/log/openvswitch/
+          name: host-var-log-ovs
+        - mountPath: /var/run/openvswitch/
+          name: host-var-run-ovs
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+        env:
+        - name: OVN_DAEMONSET_VERSION
+          value: "1.0.0"
+        - name: K8S_NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+      volumes:
+      # CNI provisioner
+      {{- if .Values.dpuManifests.externalDHCP }}
+      - name: netplan
+        hostPath:
+          path: /etc/netplan
+          type: Directory
+      - name: run-systemd
+        hostPath:
+          path: /run/systemd
+      - name: systemd-dbus
+        hostPath:
+          path: /var/run/dbus/system_bus_socket
+      - name: run-udev
+        hostPath:
+          path: /run/udev
+      - name: usr-lib-systemd-network
+        hostPath:
+          path: /usr/lib/systemd/network
+      {{- else }}
+      - name: ips
+        emptyDir: {}
+      - name: cni-bin-dir
+        hostPath:
+          path: /opt/cni/bin
+          type: Directory
+      - name: nvipam-daemon-socket-dir
+        hostPath:
+          path: /var/lib/cni/nv-ipam
+          type: Directory
+      - name: cni-cache
+        emptyDir: {}
+      {{- end }}
+      - name: init-output
+        emptyDir: {}
+      # Common volumes
+      - name: host-var-run-dbus
+        hostPath:
+          path: /var/run/dbus
+      - name: host-kubeconfig
+        hostPath:
+          path: /etc/kubernetes/
+      - name: host-kubelet
+        hostPath:
+          path: /var/lib/kubelet
+      - name: host-var-log-ovnkube
+        hostPath:
+          path: /var/log/ovn-kubernetes
+      - name: host-var-run-ovn-kubernetes
+        hostPath:
+          path: /var/run/ovn-kubernetes
+      - name: host-opt-cni-bin
+        hostPath:
+          path: /opt/cni/bin
+      - name: host-etc-cni-netd
+        hostPath:
+          path: /etc/cni/net.d
+      - name: host-slash
+        hostPath:
+          path: /
+      - name: host-netns
+        hostPath:
+          path: /var/run/netns
+      # non DPU related volumes
+      - name: host-var-log-ovs
+        hostPath:
+          path: /var/log/openvswitch
+      - name: host-run-ovs
+        hostPath:
+          path: /run/openvswitch
+      - name: host-var-run-ovs
+        hostPath:
+          path: /var/run/openvswitch
+      - name: host-ovn-cert
+        hostPath:
+          path: /etc/ovn
+          type: DirectoryOrCreate
+      - name: host-var-lib-ovs
+        hostPath:
+          path: /var/lib/openvswitch
+      - name: host-etc-ovs
+        hostPath:
+          path: /etc/openvswitch
+      - name: tenant-cluster-access-secret
+        secret:
+          defaultMode: 420
+          items:
+          - key: KUBERNETES_CA_DATA
+            path: ca.crt
+          - key: TOKEN_FILE
+            path: token
+          secretName: {{ default "" .Values.dpuManifests.kubernetesSecretName }}
+      - name: incluster
+        projected:
+          sources:
+          - secret:
+              name: {{ include "ovn-kubernetes.fullname" . }}-dpucniprovisioner-token
+              items:
+              - key: ca.crt
+                path: ca.crt
+              - key: token
+                path: token
+      tolerations:
+      - operator: "Exists"
+{{- end }}

--- a/helm/ovn-kubernetes-dpf/templates/host-with-dpu-manifests.yaml
+++ b/helm/ovn-kubernetes-dpf/templates/host-with-dpu-manifests.yaml
@@ -1,0 +1,311 @@
+{{- if .Values.nodeWithDPUManifests.enabled }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "ovn-kubernetes.fullname" . }}-node-dpu-host
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "ovn-kubernetes.fullname" . }}-node-dpu-host
+roleRef:
+  name: {{ include "ovn-kubernetes.fullname" . }}-node
+  kind: ClusterRole
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: {{ include "ovn-kubernetes.fullname" . }}-node-dpu-host
+  namespace: {{ .Release.Namespace }}
+- kind: ServiceAccount
+  name: {{ .Values.nodeWithDPUManifests.dpuServiceAccountName }}
+  namespace: {{ .Values.nodeWithDPUManifests.dpuServiceAccountNamespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "ovn-kubernetes.fullname" . }}-node-dpu-host-status-reader
+roleRef:
+  name: {{ include "ovn-kubernetes.fullname" . }}-node-status-reader
+  kind: ClusterRole
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: {{ include "ovn-kubernetes.fullname" . }}-node-dpu-host
+  namespace: {{ .Release.Namespace }}
+- kind: ServiceAccount
+  name: {{ .Values.nodeWithDPUManifests.dpuServiceAccountName }}
+  namespace: {{ .Values.nodeWithDPUManifests.dpuServiceAccountNamespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "ovn-kubernetes.fullname" . }}-node-dpu-host-configmaps
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  name: {{ include "ovn-kubernetes.fullname" . }}-configmaps
+  kind: Role
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: {{ include "ovn-kubernetes.fullname" . }}-node-dpu-host
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "ovn-kubernetes.fullname" . }}-node-dpu-host-endpoints
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  name: {{ include "ovn-kubernetes.fullname" . }}-endpoints
+  kind: Role
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: {{ include "ovn-kubernetes.fullname" . }}-node-dpu-host
+  namespace: {{ .Release.Namespace }}
+---
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: {{ include "ovn-kubernetes.fullname" . }}-node-dpu-host
+  namespace: {{ .Release.Namespace }}
+  {{- with .Values.serviceDaemonSet.labels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  annotations:
+    {{- with .Values.serviceDaemonSet.annotations }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+    kubernetes.io/description: |
+      This DaemonSet launches the ovn-kubernetes networking components for worker nodes.
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: ovnkube-node-dpu-host
+      {{- include "ovn-kubernetes.selectorLabels" . | nindent 6 }}
+      {{- with .Values.serviceDaemonSet.labels }}
+        {{- toYaml . | nindent 6 }}
+      {{- end }}
+  {{- with .Values.serviceDaemonSet.updateStrategy }}
+  updateStrategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: ovnkube-node-dpu-host
+        {{- include "ovn-kubernetes.selectorLabels" . | nindent 8 }}
+        kubernetes.io/os: "linux"
+        {{- with .Values.serviceDaemonSet.labels }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.serviceDaemonSet.annotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- with .Values.serviceDaemonSet.nodeSelector }}
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+              {{- toYaml . | nindent 12 }}
+      {{- end }}
+      {{- if .Values.imagePullSecretName }}
+      imagePullSecrets:
+      - name: {{ .Values.imagePullSecretName }}
+      {{- end }}
+      priorityClassName: "system-cluster-critical"
+      serviceAccountName: {{ include "ovn-kubernetes.fullname" . }}-node-dpu-host
+      hostNetwork: true
+      dnsPolicy: Default
+      hostPID: true
+      containers:
+      - name: ovnkube-node
+        image: {{ .Values.nodeWithDPUManifests.image.repository }}:{{ .Values.nodeWithDPUManifests.image.tag }}
+        imagePullPolicy: {{ .Values.nodeWithDPUManifests.image.pullPolicy }}
+        command: ["/root/ovnkube.sh", "ovn-node"]
+        securityContext:
+          runAsUser: 0
+          privileged: true
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /host
+          name: host-slash
+          readOnly: true
+        - mountPath: /var/run/dbus/
+          name: host-var-run-dbus
+          readOnly: true
+        - mountPath: /var/lib/kubelet
+          name: host-kubelet
+          readOnly: true
+        - mountPath: /var/log/ovn-kubernetes/
+          name: host-var-log-ovnkube
+        - mountPath: /var/run/ovn-kubernetes
+          name: host-var-run-ovn-kubernetes
+        # CNI related mounts which we take over
+        - mountPath: /opt/cni/bin
+          name: host-opt-cni-bin
+        - mountPath: /etc/cni/net.d
+          name: host-etc-cni-netd
+        - mountPath: /var/run/netns
+          name: host-netns
+          mountPropagation: Bidirectional
+        - mountPath: /var/run/ovn
+          name: var-run-ovn
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+        env:
+        - name: OVN_DAEMONSET_VERSION
+          value: "1.0.0"
+        - name: OVNKUBE_LOGLEVEL
+          value: "4"
+        - name: OVNKUBE_LOGFILE_MAXSIZE
+          value: "100"
+        - name: OVNKUBE_LOGFILE_MAXBACKUPS
+          value: "5"
+        - name: OVNKUBE_LOGFILE_MAXAGE
+          value:  "5"
+        - name: OVN_NET_CIDR
+          valueFrom:
+            configMapKeyRef:
+              name: {{ include "ovn-kubernetes.fullname" . }}-config
+              key: net_cidr
+        - name: OVN_SVC_CIDR
+          valueFrom:
+            configMapKeyRef:
+              name: {{ include "ovn-kubernetes.fullname" . }}-config
+              key: svc_cidr
+        - name: K8S_APISERVER
+          valueFrom:
+            configMapKeyRef:
+              name: {{ include "ovn-kubernetes.fullname" . }}-config
+              key: k8s_apiserver
+        - name: OVN_MTU
+          valueFrom:
+            configMapKeyRef:
+              name: {{ include "ovn-kubernetes.fullname" . }}-config
+              key: mtu
+        - name: OVN_ROUTABLE_MTU
+          valueFrom:
+            configMapKeyRef:
+              name: {{ include "ovn-kubernetes.fullname" . }}-config
+              key: routable_mtu
+              optional: true
+        - name: K8S_NODE
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: K8S_NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OVN_GATEWAY_MODE
+          value: shared
+        - name: OVN_GATEWAY_OPTS
+          value: {{ default "" .Values.gatewayOpts | quote }}
+        - name: OVN_HYBRID_OVERLAY_ENABLE
+          value: ""
+        - name: OVN_ADMIN_NETWORK_POLICY_ENABLE
+          value: ""
+        - name: OVN_EGRESSIP_ENABLE
+          value: ""
+        - name: OVN_EGRESSIP_HEALTHCHECK_PORT
+          value: "9107"
+        - name: OVN_EGRESSSERVICE_ENABLE
+          value: ""
+        - name: OVN_HYBRID_OVERLAY_NET_CIDR
+          value: ""
+        - name: OVN_DISABLE_SNAT_MULTIPLE_GWS
+          value: ""
+        - name: OVN_DISABLE_FORWARDING
+          value: ""
+        - name: OVN_ENCAP_PORT
+          value: "6081"
+        - name: OVN_DISABLE_PKT_MTU_CHECK
+          value: ""
+        - name: OVN_NETFLOW_TARGETS
+          value: ""
+        - name: OVN_SFLOW_TARGETS
+          value: ""
+        - name: OVN_IPFIX_TARGETS
+          value: ""
+        - name: OVN_IPFIX_SAMPLING
+          value: ""
+        - name: OVN_IPFIX_CACHE_MAX_FLOWS
+          value: ""
+        - name: OVN_IPFIX_CACHE_ACTIVE_TIMEOUT
+          value: ""
+        - name: OVN_V4_JOIN_SUBNET
+          value: "100.64.0.0/16"
+        - name: OVN_V6_JOIN_SUBNET
+          value: "fd98::/64"
+        - name: OVN_V4_MASQUERADE_SUBNET
+          value: "169.254.0.0/17"
+        - name: OVN_V6_MASQUERADE_SUBNET
+          value: "fd69::/112"
+        - name: OVN_MULTICAST_ENABLE
+          value: ""
+        - name: OVN_UNPRIVILEGED_MODE
+          value: "no"
+        - name: OVN_EX_GW_NETWORK_INTERFACE
+          value: ""
+        - name: OVN_ENABLE_OVNKUBE_IDENTITY
+          value: "false"
+        - name: OVNKUBE_NODE_MODE
+          value: "dpu-host"
+        - name: OVNKUBE_NODE_MGMT_PORT_NETDEV
+          value: {{ default "" .Values.nodeWithDPUManifests.nodeMgmtPortNetdev | quote }}
+        - name: OVN_HOST_NETWORK_NAMESPACE
+          valueFrom:
+            configMapKeyRef:
+              name: {{ include "ovn-kubernetes.fullname" . }}-config
+              key: host_network_namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+        readinessProbe:
+          exec:
+            command: ["/usr/bin/ovn-kube-util", "readiness-probe", "-t", "ovnkube-node"]
+          initialDelaySeconds: 30
+          timeoutSeconds: 30
+          periodSeconds: 60
+      nodeSelector:
+        kubernetes.io/os: "linux"
+        k8s.ovn.org/dpu-host: ""
+      volumes:
+      - name: host-var-run-dbus
+        hostPath:
+          path: /var/run/dbus
+      - name: host-kubelet
+        hostPath:
+          path: /var/lib/kubelet
+      - name: host-var-log-ovnkube
+        hostPath:
+          path: /var/log/ovn-kubernetes
+      - name: host-var-run-ovn-kubernetes
+        hostPath:
+          path: /var/run/ovn-kubernetes
+      - name: host-opt-cni-bin
+        hostPath:
+          path: /opt/cni/bin
+      - name: host-etc-cni-netd
+        hostPath:
+          path: /etc/cni/net.d
+      - name: host-slash
+        hostPath:
+          path: /
+      - name: host-netns
+        hostPath:
+          path: /var/run/netns
+      - name: var-run-ovn
+        emptyDir: {}
+      tolerations:
+      - operator: "Exists"
+{{- end }}

--- a/helm/ovn-kubernetes-dpf/templates/host-without-dpu-manifests.yaml
+++ b/helm/ovn-kubernetes-dpf/templates/host-without-dpu-manifests.yaml
@@ -1,0 +1,681 @@
+{{- if .Values.nodeWithoutDPUManifests.enabled }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "ovn-kubernetes.fullname" . }}-node
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "ovn-kubernetes.fullname" . }}-node
+roleRef:
+  name: {{ include "ovn-kubernetes.fullname" . }}-node
+  kind: ClusterRole
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: {{ include "ovn-kubernetes.fullname" . }}-node
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "ovn-kubernetes.fullname" . }}-node-status-reader
+roleRef:
+  name: {{ include "ovn-kubernetes.fullname" . }}-node-status-reader
+  kind: ClusterRole
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: {{ include "ovn-kubernetes.fullname" . }}-node
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "ovn-kubernetes.fullname" . }}-node-configmaps
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  name: {{ include "ovn-kubernetes.fullname" . }}-configmaps
+  kind: Role
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: {{ include "ovn-kubernetes.fullname" . }}-node
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "ovn-kubernetes.fullname" . }}-node-endpoints
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  name: {{ include "ovn-kubernetes.fullname" . }}-endpoints
+  kind: Role
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: {{ include "ovn-kubernetes.fullname" . }}-node
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: ovnkube-node
+  name: {{ include "ovn-kubernetes.fullname" . }}-node-prometheus
+  namespace: {{ .Release.Namespace }}
+spec:
+  selector:
+    app.kubernetes.io/component: ovnkube-node
+    {{- include "ovn-kubernetes.selectorLabels" . | nindent 4 }}
+  type: ClusterIP
+  clusterIP: None
+  publishNotReadyAddresses: true
+  ports:
+  - name: ovnkube-node-metrics
+    port: 9410
+    protocol: TCP
+    targetPort: 9410
+  - name: ovn-metrics
+    port: 9476
+    protocol: TCP
+    targetPort: 9476
+  - name: ovs-metrics
+    port: 9310
+    protocol: TCP
+    targetPort: 9310
+---
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: {{ include "ovn-kubernetes.fullname" . }}-node
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    kubernetes.io/description: |
+      This DaemonSet launches the ovn-kubernetes networking components for worker nodes.
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: ovnkube-node
+      {{- include "ovn-kubernetes.selectorLabels" . | nindent 6 }}
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: ovnkube-node
+        {{- include "ovn-kubernetes.selectorLabels" . | nindent 8 }}
+        kubernetes.io/os: "linux"
+        ovn-db-pod: "true"
+        ovn.dpu.nvidia.com/skip-injection: ""
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+    spec:
+      {{- if .Values.imagePullSecretName }}
+      imagePullSecrets:
+      - name: {{ .Values.imagePullSecretName }}
+      {{- end }}
+      serviceAccountName: {{ include "ovn-kubernetes.fullname" . }}-node
+      hostNetwork: true
+      dnsPolicy: Default
+      hostPID: true
+      containers:
+      - name: nb-ovsdb
+        image: {{ .Values.nodeWithoutDPUManifests.image.repository }}:{{ .Values.nodeWithoutDPUManifests.image.tag }}
+        imagePullPolicy: {{ .Values.nodeWithoutDPUManifests.image.pullPolicy }}
+        command: ["/root/ovnkube.sh", "local-nb-ovsdb"]
+        securityContext:
+          runAsUser: 0
+          capabilities:
+            add: ["NET_ADMIN"]
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /etc/openvswitch/
+          name: host-etc-ovs
+        - mountPath: /etc/ovn/
+          name: host-var-lib-ovs
+        - mountPath: /var/log/openvswitch/
+          name: host-var-log-ovs
+        - mountPath: /var/log/ovn/
+          name: host-var-log-ovs
+        - mountPath: /ovn-cert
+          name: host-ovn-cert
+          readOnly: true
+        - mountPath: /var/run/ovn/
+          name: host-var-run-ovs
+        - mountPath: /var/run/openvswitch/
+          name: host-var-run-ovs
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+        env:
+        - name: OVN_DAEMONSET_VERSION
+          value: "1.0.0"
+        - name: OVN_LOGLEVEL_NB
+          value: "-vconsole:info -vfile:info"
+        - name: K8S_APISERVER
+          valueFrom:
+            configMapKeyRef:
+              name: {{ include "ovn-kubernetes.fullname" . }}-config
+              key: k8s_apiserver
+        - name: OVN_KUBERNETES_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: K8S_NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: K8S_NODE
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        readinessProbe:
+          exec:
+            command: ["/usr/bin/ovn-kube-util", "readiness-probe", "-t", "ovnnb-db"]
+          initialDelaySeconds: 30
+          timeoutSeconds: 30
+          periodSeconds: 60
+      - name: sb-ovsdb
+        image: {{ .Values.nodeWithoutDPUManifests.image.repository }}:{{ .Values.nodeWithoutDPUManifests.image.tag }}
+        imagePullPolicy: {{ .Values.nodeWithoutDPUManifests.image.pullPolicy }}
+        command: ["/root/ovnkube.sh", "local-sb-ovsdb"]
+        securityContext:
+          runAsUser: 0
+          capabilities:
+            add: ["NET_ADMIN"]
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /etc/openvswitch/
+          name: host-etc-ovs
+        - mountPath: /etc/ovn/
+          name: host-var-lib-ovs
+        - mountPath: /var/log/openvswitch/
+          name: host-var-log-ovs
+        - mountPath: /var/log/ovn/
+          name: host-var-log-ovs
+        - mountPath: /ovn-cert
+          name: host-ovn-cert
+          readOnly: true
+        - mountPath: /var/run/ovn/
+          name: host-var-run-ovs
+        - mountPath: /var/run/openvswitch/
+          name: host-var-run-ovs
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+        env:
+        - name: OVN_DAEMONSET_VERSION
+          value: "1.0.0"
+        - name: OVN_LOGLEVEL_SB
+          value: "-vconsole:info -vfile:info"
+        - name: K8S_APISERVER
+          valueFrom:
+            configMapKeyRef:
+              name: {{ include "ovn-kubernetes.fullname" . }}-config
+              key: k8s_apiserver
+        - name: OVN_KUBERNETES_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: K8S_NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: K8S_NODE
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: OVN_SSL_ENABLE
+          value: "no"
+        readinessProbe:
+          exec:
+            command: ["/usr/bin/ovn-kube-util", "readiness-probe", "-t", "ovnsb-db"]
+          initialDelaySeconds: 30
+          timeoutSeconds: 30
+          periodSeconds: 60
+      - name: ovn-northd
+        image: {{ .Values.nodeWithoutDPUManifests.image.repository }}:{{ .Values.nodeWithoutDPUManifests.image.tag }}
+        imagePullPolicy: {{ .Values.nodeWithoutDPUManifests.image.pullPolicy }}
+        command: ["/root/ovnkube.sh", "run-ovn-northd"]
+        securityContext:
+          runAsUser: 0
+          capabilities:
+            add: ["SYS_NICE"]
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /var/run/dbus/
+          name: host-var-run-dbus
+          readOnly: true
+        - mountPath: /var/log/openvswitch/
+          name: host-var-log-ovs
+        - mountPath: /var/log/ovn/
+          name: host-var-log-ovs
+        - mountPath: /var/run/openvswitch/
+          name: host-var-run-ovs
+        - mountPath: /var/run/ovn/
+          name: host-var-run-ovs
+        - mountPath: /ovn-cert
+          name: host-ovn-cert
+          readOnly: true
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+        env:
+        - name: OVN_DAEMONSET_VERSION
+          value: "1.0.0"
+        - name: OVN_LOGLEVEL_NORTHD
+          value: "-vconsole:info -vfile:info"
+        - name: K8S_APISERVER
+          valueFrom:
+            configMapKeyRef:
+              name: {{ include "ovn-kubernetes.fullname" . }}-config
+              key: k8s_apiserver
+        - name: OVN_KUBERNETES_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: OVN_SSL_ENABLE
+          value: "no"
+        - name: OVN_NORTH
+          value: "local"
+        - name: OVN_SOUTH
+          value: "local"
+        readinessProbe:
+          exec:
+            command: ["/usr/bin/ovn-kube-util", "readiness-probe", "-t", "ovn-northd"]
+          initialDelaySeconds: 30
+          timeoutSeconds: 30
+          periodSeconds: 60
+      - name: ovnkube-controller
+        image: {{ .Values.nodeWithoutDPUManifests.image.repository }}:{{ .Values.nodeWithoutDPUManifests.image.tag }}
+        imagePullPolicy: {{ .Values.nodeWithoutDPUManifests.image.pullPolicy }}
+        command: ["/root/ovnkube.sh", "ovnkube-controller-with-node"]
+        securityContext:
+          runAsUser: 0
+          privileged: true
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /host
+          name: host-slash
+          readOnly: true
+        - mountPath: /var/lib/kubelet
+          name: host-kubelet
+          readOnly: true
+        - mountPath: /host-kubernetes
+          name: host-kubeconfig
+          readOnly: true
+        - mountPath: /var/run/dbus/
+          name: host-var-run-dbus
+          readOnly: true
+        - mountPath: /var/log/ovn-kubernetes/
+          name: host-var-log-ovnkube
+        - mountPath: /var/run/ovn-kubernetes
+          name: host-var-run-ovn-kubernetes
+        - mountPath: /opt/cni/bin
+          name: host-opt-cni-bin
+        - mountPath: /etc/cni/net.d
+          name: host-etc-cni-netd
+        - mountPath: /var/run/netns
+          name: host-netns
+          mountPropagation: Bidirectional
+        - mountPath: /var/run/openvswitch/
+          name: host-var-run-ovs
+        - mountPath: /var/run/ovn/
+          name: host-var-run-ovs
+        - mountPath: /ovn-cert
+          name: host-ovn-cert
+          readOnly: true
+        - mountPath: /etc/openvswitch/
+          name: host-etc-ovs
+          readOnly: true
+        - mountPath: /etc/ovn/
+          name: host-var-lib-ovs
+          readOnly: true
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+        env:
+        - name: OVN_EGRESSSERVICE_ENABLE
+          value: ""
+        - name: OVN_DAEMONSET_VERSION
+          value: "1.0.0"
+        - name: OVNKUBE_LOGLEVEL
+          value: "4"
+        - name: OVNKUBE_LOGFILE_MAXSIZE
+          value: "100"
+        - name: OVNKUBE_LOGFILE_MAXBACKUPS
+          value: "5"
+        - name: OVNKUBE_LOGFILE_MAXAGE
+          value: "5"
+        - name: OVNKUBE_LIBOVSDB_CLIENT_LOGFILE
+          value: ""
+        - name: OVNKUBE_CONFIG_DURATION_ENABLE
+          value: ""
+        - name: OVNKUBE_METRICS_SCALE_ENABLE
+          value: ""
+        - name: OVN_NET_CIDR
+          valueFrom:
+            configMapKeyRef:
+              name: {{ include "ovn-kubernetes.fullname" . }}-config
+              key: net_cidr
+        - name: OVN_SVC_CIDR
+          valueFrom:
+            configMapKeyRef:
+              name: {{ include "ovn-kubernetes.fullname" . }}-config
+              key: svc_cidr
+        - name: K8S_APISERVER
+          valueFrom:
+            configMapKeyRef:
+              name: {{ include "ovn-kubernetes.fullname" . }}-config
+              key: k8s_apiserver
+        - name: OVN_MTU
+          valueFrom:
+            configMapKeyRef:
+              name: {{ include "ovn-kubernetes.fullname" . }}-config
+              key: mtu
+        - name: OVN_ROUTABLE_MTU
+          valueFrom:
+            configMapKeyRef:
+              name: {{ include "ovn-kubernetes.fullname" . }}-config
+              key: routable_mtu
+              optional: true
+        - name: K8S_NODE
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: K8S_NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OVN_KUBERNETES_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: OVN_GATEWAY_MODE
+          value: shared
+        - name: OVN_GATEWAY_OPTS
+          value: ""
+        - name: OVN_HYBRID_OVERLAY_ENABLE
+          value: ""
+        - name: OVN_ADMIN_NETWORK_POLICY_ENABLE
+          value: ""
+        - name: OVN_EGRESSIP_ENABLE
+          value: ""
+        - name: OVN_EGRESSIP_HEALTHCHECK_PORT
+          value: "9107"
+        - name: OVN_EGRESSFIREWALL_ENABLE
+          value: ""
+        - name: OVN_EGRESSQOS_ENABLE
+          value: ""
+        - name: OVN_HYBRID_OVERLAY_NET_CIDR
+          value: ""
+        - name: OVN_DISABLE_SNAT_MULTIPLE_GWS
+          value: ""
+        - name: OVN_DISABLE_FORWARDING
+          value: ""
+        - name: OVN_ENCAP_PORT
+          value: "6081"
+        - name: OVN_DISABLE_PKT_MTU_CHECK
+          value: ""
+        - name: OVN_NETFLOW_TARGETS
+          value: ""
+        - name: OVN_SFLOW_TARGETS
+          value: ""
+        - name: OVN_IPFIX_TARGETS
+          value: ""
+        - name: OVN_IPFIX_SAMPLING
+          value: ""
+        - name: OVN_IPFIX_CACHE_MAX_FLOWS
+          value: ""
+        - name: OVN_IPFIX_CACHE_ACTIVE_TIMEOUT
+          value: ""
+        - name: OVN_V4_JOIN_SUBNET
+          value: "100.64.0.0/16"
+        - name: OVN_V6_JOIN_SUBNET
+          value: "fd98::/64"
+        - name: OVN_V4_MASQUERADE_SUBNET
+          value: "169.254.0.0/17"
+        - name: OVN_V6_MASQUERADE_SUBNET
+          value: "fd69::/112"
+        - name: OVN_MULTICAST_ENABLE
+          value: ""
+        - name: OVN_UNPRIVILEGED_MODE
+          value: "no"
+        - name: OVN_EX_GW_NETWORK_INTERFACE
+          value: ""
+        - name: OVN_SSL_ENABLE
+          value: "no"
+        - name: OVN_DISABLE_OVN_IFACE_ID_VER
+          value: "false"
+        - name: OVN_REMOTE_PROBE_INTERVAL
+          value: "100000"
+        - name: OVN_MONITOR_ALL
+          value: ""
+        - name: OVN_OFCTRL_WAIT_BEFORE_CLEAR
+          value: ""
+        - name: OVN_ENABLE_LFLOW_CACHE
+          value: "false"
+        - name: OVN_LFLOW_CACHE_LIMIT
+          value: ""
+        - name: OVN_LFLOW_CACHE_LIMIT_KB
+          value: ""
+        - name: OVN_MULTI_NETWORK_ENABLE
+          value: "false"
+        - name: OVNKUBE_NODE_MGMT_PORT_NETDEV
+          value: ""
+        - name: OVN_EMPTY_LB_EVENTS
+          value: ""
+        - name: OVN_ACL_LOGGING_RATE_LIMIT
+          value: "20"
+        - name: OVN_STATELESS_NETPOL_ENABLE
+          value: "true"
+        - name: OVN_HOST_NETWORK_NAMESPACE
+          valueFrom:
+            configMapKeyRef:
+              name: {{ include "ovn-kubernetes.fullname" . }}-config
+              key: host_network_namespace
+        - name: OVN_NORTH
+          value: "local"
+        - name: OVN_SOUTH
+          value: "local"
+        - name: OVN_ENABLE_INTERCONNECT
+          value: "true"
+        - name: OVN_ENABLE_MULTI_EXTERNAL_GATEWAY
+          value: "false"
+        - name: OVN_ENABLE_OVNKUBE_IDENTITY
+          value: "false"
+        - name: OVN_ENABLE_SVC_TEMPLATE_SUPPORT
+          value: "false"
+        - name: OVN_ENABLE_DNSNAMERESOLVER
+          value: "false"
+        readinessProbe:
+          exec:
+            command: ["/usr/bin/ovn-kube-util", "readiness-probe", "-t", "ovnkube-node"]
+          initialDelaySeconds: 30
+          timeoutSeconds: 30
+          periodSeconds: 60
+      - name: ovn-controller
+        image: {{ .Values.nodeWithoutDPUManifests.image.repository }}:{{ .Values.nodeWithoutDPUManifests.image.tag }}
+        imagePullPolicy: {{ .Values.nodeWithoutDPUManifests.image.pullPolicy }}
+        command: ["/root/ovnkube.sh", "ovn-controller"]
+        securityContext:
+          runAsUser: 0
+          capabilities:
+            add: ["SYS_NICE"]
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /var/run/dbus/
+          name: host-var-run-dbus
+          readOnly: true
+        - mountPath: /var/log/openvswitch/
+          name: host-var-log-ovs
+        - mountPath: /var/log/ovn/
+          name: host-var-log-ovs
+        - mountPath: /var/run/openvswitch/
+          name: host-var-run-ovs
+        - mountPath: /var/run/ovn/
+          name: host-var-run-ovs
+        - mountPath: /ovn-cert
+          name: host-ovn-cert
+          readOnly: true
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+        env:
+        - name: OVN_DAEMONSET_VERSION
+          value: "1.0.0"
+        - name: OVN_LOGLEVEL_CONTROLLER
+          value: "-vconsole:info"
+        - name: K8S_APISERVER
+          valueFrom:
+            configMapKeyRef:
+              name: {{ include "ovn-kubernetes.fullname" . }}-config
+              key: k8s_apiserver
+        - name: OVN_KUBERNETES_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: OVN_SSL_ENABLE
+          value: ""
+        - name: OVN_NORTH
+          value: "local"
+        - name: OVN_SOUTH
+          value: "local"
+        readinessProbe:
+          exec:
+            command: ["/usr/bin/ovn-kube-util", "readiness-probe", "-t", "ovn-controller"]
+          initialDelaySeconds: 30
+          timeoutSeconds: 30
+          periodSeconds: 60
+      - name: ovs-metrics-exporter
+        image: {{ .Values.nodeWithoutDPUManifests.image.repository }}:{{ .Values.nodeWithoutDPUManifests.image.tag }}
+        imagePullPolicy: {{ .Values.nodeWithoutDPUManifests.image.pullPolicy }}
+        command: ["/root/ovnkube.sh", "ovs-metrics"]
+        securityContext:
+          runAsUser: 0
+          capabilities:
+            add: ["NET_ADMIN"]
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /var/run/dbus/
+          name: host-var-run-dbus
+          readOnly: true
+        - mountPath: /var/log/openvswitch/
+          name: host-var-log-ovs
+        - mountPath: /var/run/openvswitch/
+          name: host-var-run-ovs
+          readOnly: true
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+        env:
+        - name: OVN_DAEMONSET_VERSION
+          value: "1.0.0"
+        - name: K8S_NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OVN_NORTH
+          value: "local"
+        - name: OVN_SOUTH
+          value: "local"
+      nodeSelector:
+        kubernetes.io/os: "linux"
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: k8s.ovn.org/dpu-host
+                operator: DoesNotExist
+      volumes:
+      # Common volumes
+      - name: host-var-run-dbus
+        hostPath:
+          path: /var/run/dbus
+      - name: host-kubelet
+        hostPath:
+          path: /var/lib/kubelet
+      - name: host-kubeconfig
+        hostPath:
+          path: /etc/kubernetes/
+      - name: host-var-log-ovnkube
+        hostPath:
+          path: /var/log/ovn-kubernetes
+      - name: host-var-run-ovn-kubernetes
+        hostPath:
+          path: /var/run/ovn-kubernetes
+      - name: host-opt-cni-bin
+        hostPath:
+          path: /opt/cni/bin
+      - name: host-etc-cni-netd
+        hostPath:
+          path: /etc/cni/net.d
+      - name: host-slash
+        hostPath:
+          path: /
+      - name: host-netns
+        hostPath:
+          path: /var/run/netns
+      - name: host-var-log-ovs
+        hostPath:
+          path: /var/log/openvswitch
+      - name: host-run-ovs
+        hostPath:
+          path: /run/openvswitch
+      - name: host-var-run-ovs
+        hostPath:
+          path: /var/run/openvswitch
+      - name: host-ovn-cert
+        hostPath:
+          path: /etc/ovn
+          type: DirectoryOrCreate
+      - name: host-etc-ovs
+        hostPath:
+          path: /etc/openvswitch
+      - name: host-var-lib-ovs
+        hostPath:
+          path: /var/lib/openvswitch
+      tolerations:
+      - operator: "Exists"
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app.kubernetes.io/component: ovnkube-node
+  name: {{ include "ovn-kubernetes.fullname" . }}-node-prometheus
+  namespace: {{ .Release.Namespace }}
+spec:
+  endpoints:
+  - interval: 30s
+    port: ovnkube-node-metrics
+    path: /metrics
+    scheme: http
+  - interval: 30s
+    port: ovs-metrics
+    path: /metrics
+    scheme: http
+  - interval: 30s
+    port: ovn-metrics
+    path: /metrics
+    scheme: http
+  jobLabel: k8s-app
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: ovnkube-node
+      {{- include "ovn-kubernetes.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/helm/ovn-kubernetes-dpf/values.yaml
+++ b/helm/ovn-kubernetes-dpf/values.yaml
@@ -1,0 +1,92 @@
+nameOverride: ovn-kubernetes
+
+# -- Variables related to the OVN Kubernetes Resource Injector
+ovn-kubernetes-resource-injector:
+  enabled: true
+  resourceName: nvidia.com/bf3-p0-vfs
+  controllerManager:
+    webhook:
+      command:
+      - /ovnkubernetesresourceinjector
+      image:
+        repository: ${OVNKUBERNETES_IMAGE}
+        tag: ${TAG}
+
+# -- Variables related to manifests that are deployed for nodes with DPU
+nodeWithDPUManifests:
+  enabled: true
+  image:
+    repository: ${OVNKUBERNETES_IMAGE}
+    tag: ${TAG}
+    pullPolicy: IfNotPresent
+  nodeMgmtPortNetdev: ""
+  dpuServiceAccountName: ovn-dpu
+  dpuServiceAccountNamespace: ovn-kubernetes
+
+# -- Variables related to manifests that are deployed for nodes without DPU
+nodeWithoutDPUManifests:
+  enabled: true
+  image:
+    repository: ${OVNKUBERNETES_IMAGE}
+    tag: ${TAG}
+    pullPolicy: IfNotPresent
+
+# -- Variables related to manifests that are deployed on the DPU
+dpuManifests:
+  enabled: false
+  image:
+    repository: ${OVNKUBERNETES_IMAGE}
+    tag: ${TAG}
+    pullPolicy: IfNotPresent
+  kubernetesSecretName: null # user needs to populate based on DPUServiceCredentialRequest
+  vtepCIDR: null # user needs to populate based on DPUServiceIPAM
+  hostCIDR: null # user needs to populate based on the host cluster setup
+  ipamPool: null # user needs to populate based on DPUServiceIPAM
+  ipamPoolType: null # user needs to populate based on DPUServiceIPAM
+  ipamVTEPIPIndex: 0
+  ipamPFIPIndex: 1
+  externalDHCP: false
+  gatewayDiscoveryNetwork: "169.254.99.100/32" # This is a "dummy" subnet used to get the default gateway address from DHCP server (via option 121)
+
+# -- Variables related to manifests that are needed to setup the OVN Control Plane
+controlPlaneManifests:
+  enabled: true
+  image:
+    repository: ${OVNKUBERNETES_IMAGE}
+    tag: ${TAG}
+    pullPolicy: IfNotPresent
+
+# -- Endpoint of Kubernetes API server
+k8sAPIServer: https://172.25.0.2:6443
+# -- IP range for Kubernetes pods, /14 is the top level range, under which each /23 range will be assigned to a node
+podNetwork: 10.244.0.0/16/24
+# -- A comma-separated set of CIDR notation IP ranges from which k8s assigns service cluster IPs. This should be the same as the value provided for kube-apiserver "--service-cluster-ip-range" option
+serviceNetwork: 10.96.0.0/12
+# -- Options related to setting up the gateway. Applies to all relevant manifests.
+gatewayOpts: ""
+# -- The name of the secret used to pull images. Applies to all relevant manifests.
+# TODO: Check if it should be like that or list
+imagePullSecretName: ""
+# -- MTU of network interface in a Kubernetes pod
+mtu: 1400
+
+# DPF Contract. These values are effective only for manifests related to hosts that
+# have a DPU and the DPU manifests themselves.
+serviceDaemonSet:
+  # selects nodes on which this service will run by label. Can be set in DPUService `.spec.serviceDaemonSet.nodeSelector`
+  # nodeSelector:
+  #   nodeSelectorTerms:
+  #   - matchExpressions:
+  #       - key: dpu
+  #         operator: In
+  #         values:
+  #           - dpu
+  # labels on the DaemonSet and pod template. Can be set in DPUService `.spec.serviceDaemonSet.labels`
+  labels: {}
+  # annotations on the DaemonSet and pod template. Can be set in DPUService `.spec.serviceDaemonSet.annotations`
+  annotations: {}
+  # updateStrategy on the DaemonSet. Can be set in DPUService `.spec.serviceDaemonSet.updateStrategy.`
+  updateStrategy: {}
+  #  type: RollingUpdate
+  #  rollingUpdate:
+  #    maxUnavailable: 1

--- a/helm/ovn-kubernetes-dpf/values.yaml.tmpl
+++ b/helm/ovn-kubernetes-dpf/values.yaml.tmpl
@@ -1,0 +1,92 @@
+nameOverride: ovn-kubernetes
+
+# -- Variables related to the OVN Kubernetes Resource Injector
+ovn-kubernetes-resource-injector:
+  enabled: true
+  resourceName: nvidia.com/bf3-p0-vfs
+  controllerManager:
+    webhook:
+      command:
+      - /ovnkubernetesresourceinjector
+      image:
+        repository: ${OVNKUBERNETES_IMAGE}
+        tag: ${TAG}
+
+# -- Variables related to manifests that are deployed for nodes with DPU
+nodeWithDPUManifests:
+  enabled: true
+  image:
+    repository: ${OVNKUBERNETES_IMAGE}
+    tag: ${TAG}
+    pullPolicy: IfNotPresent
+  nodeMgmtPortNetdev: ""
+  dpuServiceAccountName: ovn-dpu
+  dpuServiceAccountNamespace: ovn-kubernetes
+
+# -- Variables related to manifests that are deployed for nodes without DPU
+nodeWithoutDPUManifests:
+  enabled: true
+  image:
+    repository: ${OVNKUBERNETES_IMAGE}
+    tag: ${TAG}
+    pullPolicy: IfNotPresent
+
+# -- Variables related to manifests that are deployed on the DPU
+dpuManifests:
+  enabled: false
+  image:
+    repository: ${OVNKUBERNETES_IMAGE}
+    tag: ${TAG}
+    pullPolicy: IfNotPresent
+  kubernetesSecretName: null # user needs to populate based on DPUServiceCredentialRequest
+  vtepCIDR: null # user needs to populate based on DPUServiceIPAM
+  hostCIDR: null # user needs to populate based on the host cluster setup
+  ipamPool: null # user needs to populate based on DPUServiceIPAM
+  ipamPoolType: null # user needs to populate based on DPUServiceIPAM
+  ipamVTEPIPIndex: 0
+  ipamPFIPIndex: 1
+  externalDHCP: false
+  gatewayDiscoveryNetwork: "169.254.99.100/32" # This is a "dummy" subnet used to get the default gateway address from DHCP server (via option 121)
+
+# -- Variables related to manifests that are needed to setup the OVN Control Plane
+controlPlaneManifests:
+  enabled: true
+  image:
+    repository: ${OVNKUBERNETES_IMAGE}
+    tag: ${TAG}
+    pullPolicy: IfNotPresent
+
+# -- Endpoint of Kubernetes API server
+k8sAPIServer: https://172.25.0.2:6443
+# -- IP range for Kubernetes pods, /14 is the top level range, under which each /23 range will be assigned to a node
+podNetwork: 10.244.0.0/16/24
+# -- A comma-separated set of CIDR notation IP ranges from which k8s assigns service cluster IPs. This should be the same as the value provided for kube-apiserver "--service-cluster-ip-range" option
+serviceNetwork: 10.96.0.0/12
+# -- Options related to setting up the gateway. Applies to all relevant manifests.
+gatewayOpts: ""
+# -- The name of the secret used to pull images. Applies to all relevant manifests.
+# TODO: Check if it should be like that or list
+imagePullSecretName: ""
+# -- MTU of network interface in a Kubernetes pod
+mtu: 1400
+
+# DPF Contract. These values are effective only for manifests related to hosts that
+# have a DPU and the DPU manifests themselves.
+serviceDaemonSet:
+  # selects nodes on which this service will run by label. Can be set in DPUService `.spec.serviceDaemonSet.nodeSelector`
+  # nodeSelector:
+  #   nodeSelectorTerms:
+  #   - matchExpressions:
+  #       - key: dpu
+  #         operator: In
+  #         values:
+  #           - dpu
+  # labels on the DaemonSet and pod template. Can be set in DPUService `.spec.serviceDaemonSet.labels`
+  labels: {}
+  # annotations on the DaemonSet and pod template. Can be set in DPUService `.spec.serviceDaemonSet.annotations`
+  annotations: {}
+  # updateStrategy on the DaemonSet. Can be set in DPUService `.spec.serviceDaemonSet.updateStrategy.`
+  updateStrategy: {}
+  #  type: RollingUpdate
+  #  rollingUpdate:
+  #    maxUnavailable: 1


### PR DESCRIPTION
Move from multi chart to a single chart + resource injector as separate chart to be able to make use of the serviceDaemonSet variables correctly in the relevant resources.

The old chart remains as is, but can be removed after we start using this chart, up to the team to decide.