### PR TITLE
fix: move imagePullSecret to global variables

### DIFF
--- a/helm/ovn-kubernetes-dpf/templates/control-plane-manifests.yaml
+++ b/helm/ovn-kubernetes-dpf/templates/control-plane-manifests.yaml
@@ -158,9 +158,9 @@ spec:
         kubernetes.io/os: "linux"
         ovn.dpu.nvidia.com/skip-injection: ""
     spec:
-      {{- if .Values.imagePullSecretName }}
+      {{- if .Values.global.imagePullSecretName }}
       imagePullSecrets:
-      - name: {{ .Values.imagePullSecretName }}
+      - name: {{ .Values.global.imagePullSecretName }}
       {{- end }}
       priorityClassName: "system-cluster-critical"
       serviceAccountName: {{ include "ovn-kubernetes.fullname" . }}-cluster-manager

--- a/helm/ovn-kubernetes-dpf/templates/dpu-manifests.yaml
+++ b/helm/ovn-kubernetes-dpf/templates/dpu-manifests.yaml
@@ -164,9 +164,9 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
               {{- toYaml . | nindent 12 }}
       {{- end }}
-      {{- if .Values.imagePullSecretName }}
+      {{- if .Values.global.imagePullSecretName }}
       imagePullSecrets:
-      - name: {{ .Values.imagePullSecretName }}
+      - name: {{ .Values.global.imagePullSecretName }}
       {{- end }}
       priorityClassName: "system-cluster-critical"
       serviceAccountName: {{ include "ovn-kubernetes.fullname" . }}-node

--- a/helm/ovn-kubernetes-dpf/templates/host-with-dpu-manifests.yaml
+++ b/helm/ovn-kubernetes-dpf/templates/host-with-dpu-manifests.yaml
@@ -113,9 +113,9 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
               {{- toYaml . | nindent 12 }}
       {{- end }}
-      {{- if .Values.imagePullSecretName }}
+      {{- if .Values.global.imagePullSecretName }}
       imagePullSecrets:
-      - name: {{ .Values.imagePullSecretName }}
+      - name: {{ .Values.global.imagePullSecretName }}
       {{- end }}
       priorityClassName: "system-cluster-critical"
       serviceAccountName: {{ include "ovn-kubernetes.fullname" . }}-node-dpu-host

--- a/helm/ovn-kubernetes-dpf/templates/host-without-dpu-manifests.yaml
+++ b/helm/ovn-kubernetes-dpf/templates/host-without-dpu-manifests.yaml
@@ -114,9 +114,9 @@ spec:
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
-      {{- if .Values.imagePullSecretName }}
+      {{- if .Values.global.imagePullSecretName }}
       imagePullSecrets:
-      - name: {{ .Values.imagePullSecretName }}
+      - name: {{ .Values.global.imagePullSecretName }}
       {{- end }}
       serviceAccountName: {{ include "ovn-kubernetes.fullname" . }}-node
       hostNetwork: true

--- a/helm/ovn-kubernetes-dpf/values.yaml
+++ b/helm/ovn-kubernetes-dpf/values.yaml
@@ -64,11 +64,12 @@ podNetwork: 10.244.0.0/16/24
 serviceNetwork: 10.96.0.0/12
 # -- Options related to setting up the gateway. Applies to all relevant manifests.
 gatewayOpts: ""
-# -- The name of the secret used to pull images. Applies to all relevant manifests.
-# TODO: Check if it should be like that or list
-imagePullSecretName: ""
 # -- MTU of network interface in a Kubernetes pod
 mtu: 1400
+
+global:
+  # -- The name of the secret used to pull images. Applies to all relevant manifests.
+  imagePullSecretName: ""
 
 # DPF Contract. These values are effective only for manifests related to hosts that
 # have a DPU and the DPU manifests themselves.

--- a/helm/ovn-kubernetes-dpf/values.yaml.tmpl
+++ b/helm/ovn-kubernetes-dpf/values.yaml.tmpl
@@ -64,11 +64,12 @@ podNetwork: 10.244.0.0/16/24
 serviceNetwork: 10.96.0.0/12
 # -- Options related to setting up the gateway. Applies to all relevant manifests.
 gatewayOpts: ""
-# -- The name of the secret used to pull images. Applies to all relevant manifests.
-# TODO: Check if it should be like that or list
-imagePullSecretName: ""
 # -- MTU of network interface in a Kubernetes pod
 mtu: 1400
+
+global:
+  # -- The name of the secret used to pull images. Applies to all relevant manifests.
+  imagePullSecretName: ""
 
 # DPF Contract. These values are effective only for manifests related to hosts that
 # have a DPU and the DPU manifests themselves.


### PR DESCRIPTION
This is so that the injector can also get the imagePullSecret.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->